### PR TITLE
Corrects rust code block labels in READMEs

### DIFF
--- a/sb-on-demand-feeds/README.md
+++ b/sb-on-demand-feeds/README.md
@@ -18,7 +18,7 @@ anchor build
 ```
 After building, take note of your program address and insert it in your program `lib.rs` file here:
 *Note:* an easy command to view your recently built programm address - `anchor keys list`.
-```typescript
+```rust
 declare_id!(“[YOUR_PROGRAM_ADDRESS]“);
 ```
 Rebuild your program.

--- a/sb-on-demand-secret/sb-on-demand-secrets-socials/README.md
+++ b/sb-on-demand-secret/sb-on-demand-secrets-socials/README.md
@@ -20,7 +20,7 @@ anchor build
 ```
 After building, take note of your program address and insert it in your program `lib.rs` file here:
 *Note:* an easy command to view your recently built programm address - `anchor keys list`.
-```typescript
+```rust
 declare_id!(“[YOUR_PROGRAM_ADDRESS]“);
 ```
 Rebuild your program.

--- a/sb-on-demand-secret/sb-on-demand-secrets/README.md
+++ b/sb-on-demand-secret/sb-on-demand-secrets/README.md
@@ -18,7 +18,7 @@ anchor build
 ```
 After building, take note of your program address and insert it in your program `lib.rs` file here:
 *Note:* an easy command to view your recently built programm address - `anchor keys list`.
-```typescript
+```rust
 declare_id!(“[YOUR_PROGRAM_ADDRESS]“);
 ```
 Rebuild your program.

--- a/sb-randomness-on-demand/README.md
+++ b/sb-randomness-on-demand/README.md
@@ -28,7 +28,7 @@ anchor build
 ```
 After building, take note of your program address and insert it in your program `lib.rs` file here:
 *Note:* an easy command to view your recently built programm address - `anchor keys list`.
-```typescript
+```rust
 declare_id!(“[YOUR_PROGRAM_ADDRESS]“);
 ```
 Rebuild your program.


### PR DESCRIPTION

Hey, this for making this nice example repo! 🙂 👍

I noticed that these "declare_id!" code snippets were labeled as typescript, but I think this is a typo since that comes from the Rust code! :)