### PR TITLE
fix: Check randomness account

### DIFF
--- a/sb-randomness-on-demand/sb-randomness/programs/sb-randomness/src/lib.rs
+++ b/sb-randomness-on-demand/sb-randomness/programs/sb-randomness/src/lib.rs
@@ -95,6 +95,12 @@ pub mod sb_randomness {
     pub fn settle_flip(ctx: Context<SettleFlip>, escrow_bump: u8) -> Result<()> {
         let clock: Clock = Clock::get()?;
         let player_state = &mut ctx.accounts.player_state;
+
+        // Verify that the provided randomness account matches the stored one
+        if ctx.accounts.randomness_account_data.key() != player_state.randomness_account {
+            return Err(ErrorCode::InvalidRandomnessAccount.into());
+        }
+
         // call the switchboard on-demand parse function to get the randomness data
         let randomness_data =
             RandomnessAccountData::parse(ctx.accounts.randomness_account_data.data.borrow())
@@ -216,4 +222,5 @@ pub enum ErrorCode {
     RandomnessAlreadyRevealed,
     RandomnessNotResolved,
     RandomnessExpired,
+    InvalidRandomnessAccount,
 }


### PR DESCRIPTION
There was a security vulnerability in the `settle_flip` function. The issue is now fixed by adding validation that ensures the randomness account provided in the `settle_flip` function matches the one recorded during the `coin_flip` call.