### PR TITLE
Examples: add shared EVM network switch and upgrade SDK pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ The EVM examples showcase Switchboard functionality on EVM-compatible chains:
 - **[📈 Price Feeds](./evm)** - Real-time price data for DeFi applications
 - **[🎲 On-Demand Randomness](./evm/randomness/)** - Verifiable Random Function (VRF)
 
+**Monad Network Switch:**
+- The runnable Monad EVM examples now use a single env var: `NETWORK=monad-testnet` or `NETWORK=monad-mainnet`
+- `RPC_URL` is optional and overrides the default endpoint for the selected network
+- The packaged scripts validate chain ID, Switchboard address, and reused contract addresses before broadcast
+
 **Supported Networks:**
 - Monad (Mainnet & Testnet)
 - Hyperliquid (Mainnet)

--- a/common/bun.lock
+++ b/common/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@switchboard-xyz/common-examples",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.4.0",
-        "@switchboard-xyz/on-demand": "^3.7.3",
+        "@switchboard-xyz/common": "^5.7.0",
+        "@switchboard-xyz/on-demand": "^3.9.0",
         "yaml": "^2.8.2",
       },
     },
@@ -74,11 +74,11 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.18", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ=="],
 
-    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.6.1", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-2Sz3iAusCnpEp+lJLOcwstRxGQCkbCdLDNgAYl/gTqApCA+drdQni8WoeKdahAXtcxhr72pd9PhFi/4N25im+w=="],
+    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.7.0", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg=="],
 
-    "@switchboard-xyz/common-legacy": ["@switchboard-xyz/common-legacy@1.0.2", "", { "dependencies": { "@switchboard-xyz/common": "5.5.2", "axios": "^1.9.0", "bs58": "^6.0.0" } }, "sha512-2DGJiqIvw+ekmujcntIwO1UNcBZr1pbX7XTWcOUs2JChIqh3ceSV8jyLeyHGAi+/0eGmgF0pluxizstyf9bbzA=="],
+    "@switchboard-xyz/common-legacy": ["@switchboard-xyz/common-legacy@1.1.0", "", { "dependencies": { "@switchboard-xyz/common": "5.7.0", "axios": "^1.9.0", "bs58": "^6.0.0" } }, "sha512-8MWCkOK0ystMWY5Txlh1o+8ZJ4ksUrifWWpNJoyds7qtmTaY2nSK8gKG7AORTtktTOS9K9tdDR4RSYoLtZAJOA=="],
 
-    "@switchboard-xyz/on-demand": ["@switchboard-xyz/on-demand@3.8.2", "", { "dependencies": { "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1", "@isaacs/ttlcache": "^1.4.1", "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.98.4", "@switchboard-xyz/common": "^5.6.1", "@switchboard-xyz/common-legacy": "^1.0.2", "axios": "^1.9", "bs58": "^6.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "isomorphic-ws": "^5.0.0", "js-yaml": "^4.1.0", "tweetnacl": "^1.0.3", "ws": "^8.18.1" } }, "sha512-j7I9m6g4UfMx9Hewo2b58+Rt2DqS1ii8+ztNXsF/HV5Oms3ImoIEdffvP8GPJGbORd7IAlRtjXYjaAoR2kay7g=="],
+    "@switchboard-xyz/on-demand": ["@switchboard-xyz/on-demand@3.9.0", "", { "dependencies": { "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1", "@isaacs/ttlcache": "^1.4.1", "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.98.4", "@switchboard-xyz/common": "^5.7.0", "@switchboard-xyz/common-legacy": "^1.1.0", "axios": "^1.9", "bs58": "^6.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "isomorphic-ws": "^5.0.0", "js-yaml": "^4.1.0", "tweetnacl": "^1.0.3", "ws": "^8.18.1" } }, "sha512-6rRGCiPoSaWgBL/ixnOKf/O42BXQdZFpQz81bAvdwCCvjmOTruZ5Ie+iJadDe3339vvPGRrJd4UTuHoU/scJ1Q=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -281,8 +281,6 @@
     "@solana/options/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
     "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
-
-    "@switchboard-xyz/common-legacy/@switchboard-xyz/common": ["@switchboard-xyz/common@5.5.2", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-/94ZkCaB1fnrjd7KW2YA702lSi/nJMrELNu0eyxOq6LU0OwX18LDo6muKyVCuKEHgGM64I0HJeOT1MtUgeVMBw=="],
 
     "borsh/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 

--- a/common/package.json
+++ b/common/package.json
@@ -9,8 +9,8 @@
     "twitter": "bun run twitter-follower-count/getFollowerCount.ts"
   },
   "dependencies": {
-    "@switchboard-xyz/common": "^5.4.0",
-    "@switchboard-xyz/on-demand": "^3.7.3",
+    "@switchboard-xyz/common": "^5.7.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
     "yaml": "^2.8.2"
   }
 }

--- a/common/twitter-follower-count/getFollowerCount.ts
+++ b/common/twitter-follower-count/getFollowerCount.ts
@@ -1,5 +1,5 @@
 import { CrossbarClient, OracleJob } from "@switchboard-xyz/common";
-import { getAccessToken } from "./oauth.ts";
+import { getAccessToken } from "./oauth";
 
 /**
  * Creates an Oracle Job definition to fetch Twitter/X follower count
@@ -94,7 +94,7 @@ function getTwitterFollowerCountJob(username: string): OracleJob {
   // Mask any tokens in error messages
   let errorMessage = error.message || String(error);
   // Replace any long alphanumeric strings that look like tokens
-  errorMessage = errorMessage.replace(/[A-Za-z0-9]{20,}/g, (match) => {
+  errorMessage = errorMessage.replace(/[A-Za-z0-9]{20,}/g, (match: string) => {
     return match.slice(0, 5) + "***";
   });
 

--- a/common/twitter-follower-count/package-lock.json
+++ b/common/twitter-follower-count/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.2.2"
+        "@switchboard-xyz/common": "^5.7.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
@@ -695,9 +696,9 @@
       }
     },
     "node_modules/@switchboard-xyz/common": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.2.2.tgz",
-      "integrity": "sha512-cvxssAmQrYBhAi9DqtePpDcFkUG/KOhDWU8lRS8prOol5pQAYxXjbuzGUGt6ekEDlNTj15i7mOUdVjJ1e3r+Aw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.7.0.tgz",
+      "integrity": "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg==",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.2",
@@ -708,9 +709,7 @@
         "buffer": "^6.0.3",
         "decimal.js": "^10.4.3",
         "js-sha256": "^0.11.0",
-        "protobufjs": "^7.4.0",
-        "yaml": "^2.6.1",
-        "zod": "4.0.0-beta.20250505T195954"
+        "protobufjs": "^7.4.0"
       },
       "engines": {
         "node": ">=20"
@@ -747,15 +746,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@zod/core": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@zod/core/-/core-0.11.6.tgz",
-      "integrity": "sha512-03Bv82fFSfjDAvMfdHHdGSS6SOJs0iCcJlWJv1kJHRtoTT02hZpyip/2Lk6oo4l4FtjuwTrsEQTwg/LD8I7dJA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/agentkeepalive": {
@@ -1629,7 +1619,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -1647,27 +1636,18 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.0.0-beta.20250505T195954",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.0-beta.20250505T195954.tgz",
-      "integrity": "sha512-iB8WvxkobVIXMARvQu20fKvbS7mUTiYRpcD8OQV1xjRhxO0EEpYIRJBk6yfBzHAHEdOSDh3SxDITr5Eajr2vtg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zod/core": "0.11.6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/common/twitter-follower-count/package.json
+++ b/common/twitter-follower-count/package.json
@@ -19,7 +19,8 @@
   "author": "Switchboard",
   "license": "MIT",
   "dependencies": {
-    "@switchboard-xyz/common": "^5.2.2"
+    "@switchboard-xyz/common": "^5.7.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",

--- a/evm/README.md
+++ b/evm/README.md
@@ -13,6 +13,28 @@ Switchboard On-Demand oracle functionality for EVM-compatible chains.
 
 > For legacy EVM chains (Arbitrum, Core, etc.), see the [legacy examples](./legacy/).
 
+## Network Switch
+
+All runnable EVM examples now use the same network contract:
+
+- `NETWORK=monad-testnet` or `NETWORK=monad-mainnet`
+- `RPC_URL` is optional and overrides the default RPC for the selected network
+- `PRIVATE_KEY` is required for any transaction
+- `SWITCHBOARD_ADDRESS` is an advanced override only
+
+Defaults:
+
+- `NETWORK=monad-testnet`
+- Monad testnet RPC: `https://testnet-rpc.monad.xyz`
+- Monad mainnet RPC: `https://rpc.monad.xyz`
+
+Guardrails:
+
+- Unknown `NETWORK` values fail fast
+- A mismatched `RPC_URL` fails before broadcast
+- Monad examples reject a `SWITCHBOARD_ADDRESS` that does not match the canonical address for the selected network
+- Reused contract addresses are checked for deployed bytecode before use
+
 ## 🚀 Quick Start
 
 Each example is a standalone Foundry project. Navigate to the specific example and follow its README.
@@ -24,18 +46,24 @@ Each example is a standalone Foundry project. Navigate to the specific example a
 cd evm/price-feeds
 bun install && forge build
 cp .env.example .env  # Edit .env with your private key
+
+# Default: Monad testnet
 bun run example
 
-# Direct Randomness Example
-cd ../randomness
+# Flip everything to Monad mainnet with one env var
+NETWORK=monad-mainnet bun run example
+
+# Randomness Examples
+cd ../randomness/coin-flip   # or pancake-stacker
+bun install && forge build
+cp .env.example .env  # Edit .env with your private key
+bun run deploy
+bun run flip
+
+# Generic randomness helper
+cd ../
 bun install
 bun run example
-
-# Contract-backed Randomness Examples
-cd coin-flip   # or pancake-stacker
-bun install && forge build
-cp .env.example .env  # Edit .env with your private key and deployed contract address
-bun run flip
 ```
 
 ## 📁 Directory Structure
@@ -50,9 +78,7 @@ evm/
 ├── randomness/                 # Randomness examples
 │   ├── coin-flip/              # Coin flip example
 │   ├── pancake-stacker/        # Pancake stacking game
-│   ├── package.json            # Core randomness example package
-│   ├── randomness.ts           # Core randomness example
-│   └── utils.ts                # Shared helpers
+│   └── randomness.ts           # Core randomness utilities
 │
 └── legacy/                     # Archived implementation
 ```
@@ -84,13 +110,15 @@ const signer = new ethers.Wallet(privateKey, provider);
 
 // Fetch oracle data
 const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
-const response = await crossbar.fetchOracleQuote([feedHash], 'mainnet');
-const updates = [response.encoded];
+const { encoded } = await crossbar.fetchEVMResults({
+  chainId: 143,
+  aggregatorIds: [feedHash],
+});
 
 // Submit update
 const switchboard = new ethers.Contract(switchboardAddress, SWITCHBOARD_ABI, signer);
-const fee = await switchboard.getFee(updates);
-const tx = await contract.updatePrices(updates, [feedHash], { value: fee });
+const fee = await switchboard.getFee(encoded);
+const tx = await contract.updatePrices(encoded, [feedHash], { value: fee });
 await tx.wait();
 
 // Query price
@@ -295,4 +323,4 @@ const diceRoll = Number((result.value % 6n) + 1n);
 - [Switchboard Explorer](https://explorer.switchboard.xyz)
 - [Feed Builder](https://explorer.switchboard.xyz/feed-builder)
 - [Solidity SDK](https://www.npmjs.com/package/@switchboard-xyz/on-demand-solidity)
-- [Discord](https://discord.gg/TJAv6ZYvPC)
+- [Discord](https://discord.gg/switchboardxyz)

--- a/evm/network.ts
+++ b/evm/network.ts
@@ -1,0 +1,317 @@
+import { spawn } from "node:child_process";
+
+export type ExampleNetwork =
+  | "monad-testnet"
+  | "monad-mainnet"
+  | "hyperliquid-mainnet";
+
+export interface NetworkConfig {
+  key: ExampleNetwork;
+  name: string;
+  chainId: number;
+  defaultRpcUrl: string;
+  switchboard: string;
+  explorer: string;
+  nativeSymbol: string;
+  family: "monad" | "hyperliquid";
+}
+
+export interface ResolvedNetworkConfig extends NetworkConfig {
+  rpcUrl: string;
+}
+
+const NETWORKS: Record<ExampleNetwork, Omit<NetworkConfig, "key">> = {
+  "monad-testnet": {
+    name: "Monad Testnet",
+    chainId: 10143,
+    defaultRpcUrl: "https://testnet-rpc.monad.xyz",
+    switchboard: "0x6724818814927e057a693f4e3A172b6cC1eA690C",
+    explorer: "https://testnet.monadscan.io",
+    nativeSymbol: "MON",
+    family: "monad",
+  },
+  "monad-mainnet": {
+    name: "Monad Mainnet",
+    chainId: 143,
+    defaultRpcUrl: "https://rpc.monad.xyz",
+    switchboard: "0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67",
+    explorer: "https://mainnet-beta.monvision.io",
+    nativeSymbol: "MON",
+    family: "monad",
+  },
+  "hyperliquid-mainnet": {
+    name: "Hyperliquid Mainnet",
+    chainId: 999,
+    defaultRpcUrl: "https://rpc.hyperliquid.xyz/evm",
+    switchboard: "0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347",
+    explorer: "https://explorer.hyperliquid.xyz",
+    nativeSymbol: "ETH",
+    family: "hyperliquid",
+  },
+};
+
+export const DEFAULT_NETWORK: ExampleNetwork = "monad-testnet";
+export const MONAD_NETWORKS: readonly ExampleNetwork[] = [
+  "monad-testnet",
+  "monad-mainnet",
+];
+
+interface ResolveNetworkOptions {
+  allowedNetworks?: readonly ExampleNetwork[];
+  defaultNetwork?: ExampleNetwork;
+}
+
+function assertHexAddress(address: string, label: string): string {
+  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    throw new Error(`Invalid ${label} address: ${address}`);
+  }
+  return address;
+}
+
+function normalizeAddress(address: string, label: string): string {
+  return assertHexAddress(address, label).toLowerCase();
+}
+
+function formatUnits(value: bigint, decimals: number): string {
+  const divisor = 10n ** BigInt(decimals);
+  const whole = value / divisor;
+  const fraction = value % divisor;
+
+  if (fraction === 0n) {
+    return whole.toString();
+  }
+
+  const fractionString = fraction.toString().padStart(decimals, "0");
+  return `${whole}.${fractionString.replace(/0+$/, "")}`;
+}
+
+async function rpcCall<T>(
+  rpcUrl: string,
+  method: string,
+  params: unknown[]
+): Promise<T> {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${method} failed with HTTP ${response.status}`);
+  }
+
+  const body = await response.json();
+  if (body.error) {
+    throw new Error(`${method} failed: ${body.error.message}`);
+  }
+
+  return body.result as T;
+}
+
+export function listNetworks(
+  allowedNetworks: readonly ExampleNetwork[] = Object.keys(
+    NETWORKS
+  ) as ExampleNetwork[]
+): string {
+  return allowedNetworks.join(", ");
+}
+
+export function resolveNetworkConfig(
+  options: ResolveNetworkOptions = {}
+): ResolvedNetworkConfig {
+  const allowedNetworks =
+    options.allowedNetworks ||
+    (Object.keys(NETWORKS) as ExampleNetwork[]);
+  const requestedNetwork =
+    (process.env.NETWORK?.trim() as ExampleNetwork | undefined) ||
+    options.defaultNetwork ||
+    DEFAULT_NETWORK;
+
+  if (!allowedNetworks.includes(requestedNetwork)) {
+    throw new Error(
+      `Unknown NETWORK="${requestedNetwork}". Allowed values: ${listNetworks(
+        allowedNetworks
+      )}`
+    );
+  }
+
+  const base = NETWORKS[requestedNetwork];
+  const rpcUrl = process.env.RPC_URL?.trim() || base.defaultRpcUrl;
+  const manualSwitchboard = process.env.SWITCHBOARD_ADDRESS?.trim();
+
+  if (manualSwitchboard && base.family === "monad") {
+    const expectedSwitchboard = normalizeAddress(
+      base.switchboard,
+      `${requestedNetwork} Switchboard`
+    );
+    const providedSwitchboard = normalizeAddress(
+      manualSwitchboard,
+      "SWITCHBOARD_ADDRESS"
+    );
+
+    if (providedSwitchboard !== expectedSwitchboard) {
+      throw new Error(
+        `SWITCHBOARD_ADDRESS=${manualSwitchboard} does not match the canonical ${requestedNetwork} Switchboard address ${base.switchboard}`
+      );
+    }
+  }
+
+  return {
+    key: requestedNetwork,
+    ...base,
+    rpcUrl,
+    switchboard: manualSwitchboard || base.switchboard,
+  };
+}
+
+export function requirePrivateKey(): string {
+  const privateKey = process.env.PRIVATE_KEY?.trim();
+  if (!privateKey) {
+    throw new Error("PRIVATE_KEY environment variable is required");
+  }
+  if (!/^0x[a-fA-F0-9]{64}$/.test(privateKey)) {
+    throw new Error("PRIVATE_KEY must be a 32-byte hex string");
+  }
+  return privateKey;
+}
+
+export async function assertRpcMatchesNetwork(
+  config: ResolvedNetworkConfig
+): Promise<void> {
+  const chainIdHex = await rpcCall<string>(config.rpcUrl, "eth_chainId", []);
+  const actualChainId = Number.parseInt(chainIdHex, 16);
+
+  if (actualChainId !== config.chainId) {
+    throw new Error(
+      `RPC_URL resolved to chain ID ${actualChainId}, but NETWORK=${config.key} requires chain ID ${config.chainId}`
+    );
+  }
+}
+
+export async function assertContractCode(
+  config: ResolvedNetworkConfig,
+  address: string,
+  label: string
+): Promise<string> {
+  const normalizedAddress = assertHexAddress(address, label);
+  const code = await rpcCall<string>(
+    config.rpcUrl,
+    "eth_getCode",
+    [normalizedAddress, "latest"]
+  );
+
+  if (code === "0x") {
+    throw new Error(
+      `No bytecode found at ${label} address ${normalizedAddress}`
+    );
+  }
+
+  return normalizedAddress;
+}
+
+export async function getValidatedNetwork(
+  options: ResolveNetworkOptions = {}
+): Promise<ResolvedNetworkConfig> {
+  const config = resolveNetworkConfig(options);
+  await assertRpcMatchesNetwork(config);
+  await assertContractCode(config, config.switchboard, "Switchboard");
+  return config;
+}
+
+export async function requireDeployedContract(
+  config: ResolvedNetworkConfig,
+  envVar: string,
+  label: string
+): Promise<string> {
+  const address = process.env[envVar]?.trim();
+  if (!address) {
+    throw new Error(`${envVar} environment variable is required`);
+  }
+  return assertContractCode(config, address, label);
+}
+
+export async function getNativeBalance(
+  config: ResolvedNetworkConfig,
+  address: string
+): Promise<bigint> {
+  const normalizedAddress = assertHexAddress(address, "wallet");
+  const balanceHex = await rpcCall<string>(
+    config.rpcUrl,
+    "eth_getBalance",
+    [normalizedAddress, "latest"]
+  );
+  return BigInt(balanceHex);
+}
+
+export function formatNativeBalance(value: bigint): string {
+  return formatUnits(value, 18);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface ForgeDeployOptions {
+  script: string;
+  label: string;
+  allowedNetworks?: readonly ExampleNetwork[];
+  extraArgs?: string[];
+}
+
+export async function runForgeDeploy(
+  options: ForgeDeployOptions
+): Promise<void> {
+  requirePrivateKey();
+  const config = await getValidatedNetwork({
+    allowedNetworks: options.allowedNetworks,
+  });
+
+  console.log(`Deploying ${options.label}`);
+  console.log(`  Network: ${config.name} (${config.key})`);
+  console.log(`  Chain ID: ${config.chainId}`);
+  console.log(`  RPC URL: ${config.rpcUrl}`);
+  console.log(`  Switchboard: ${config.switchboard}`);
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      "forge",
+      [
+        "script",
+        options.script,
+        "--rpc-url",
+        config.rpcUrl,
+        "--broadcast",
+        "-vvvv",
+        ...(options.extraArgs ?? []),
+      ],
+      {
+        cwd: process.cwd(),
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          NETWORK: config.key,
+          RPC_URL: config.rpcUrl,
+          SWITCHBOARD_ADDRESS: config.switchboard,
+        },
+      }
+    );
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `forge script exited with status ${code ?? "unknown"}`
+        )
+      );
+    });
+  });
+}

--- a/evm/price-feeds/.env.example
+++ b/evm/price-feeds/.env.example
@@ -7,6 +7,9 @@ NETWORK=monad-testnet
 # RPC URL (optional - uses default for network if not set)
 RPC_URL=
 
+# Advanced override only. For Monad, this must match the canonical address for the selected NETWORK.
+SWITCHBOARD_ADDRESS=
+
 # Deployed contract address (optional - will deploy new if not set)
 CONTRACT_ADDRESS=
 

--- a/evm/price-feeds/DEPLOYMENT.md
+++ b/evm/price-feeds/DEPLOYMENT.md
@@ -1,342 +1,160 @@
-# Deployment Guide for EVM Chains
+# Deployment Guide for EVM Price Feeds
 
-This guide walks you through deploying the SwitchboardPriceConsumer contract to various EVM chains, with a focus on Monad.
+This guide covers the packaged deployment flow for `evm/price-feeds`.
 
 ## Prerequisites
 
-1. **Foundry installed**
-   ```bash
-   curl -L https://foundry.paradigm.xyz | bash
-   foundryup
-   ```
+- [Foundry](https://book.getfoundry.sh/getting-started/installation)
+- [Bun](https://bun.sh/)
+- A funded wallet on the target Monad network
 
-2. **Bun or Node.js installed**
-   ```bash
-   curl -fsSL https://bun.sh/install | bash
-   ```
+## Environment Contract
 
-3. **Wallet with native tokens**
-   - Monad Testnet: Get MON from faucet
-   - Monad Mainnet: Purchase MON tokens
-   - Other chains: Get respective native tokens
+The example uses one network switch for deploys and runtime scripts:
 
-## Step 1: Configure Environment
+- `NETWORK=monad-testnet` or `NETWORK=monad-mainnet`
+- `RPC_URL` optional override
+- `PRIVATE_KEY` required
+- `SWITCHBOARD_ADDRESS` advanced override only
 
-Create a `.env` file:
+Defaults:
 
-```bash
-PRIVATE_KEY=0xyour_private_key_here
-RPC_URL=https://your_rpc_url_here
+- `NETWORK=monad-testnet`
+- Testnet RPC: `https://testnet-rpc.monad.xyz`
+- Mainnet RPC: `https://rpc.monad.xyz`
 
-# Optional (for specific networks)
-SWITCHBOARD_ADDRESS=0x...  # Override default Switchboard address
-NETWORK=monad-testnet      # Network name for scripts
-CONTRACT_ADDRESS=0x...     # Reuse an existing consumer instead of deploying a new one
-```
+Canonical Switchboard addresses:
 
-### Network-Specific RPC URLs
+| Network | Chain ID | Switchboard |
+| --- | --- | --- |
+| Monad Testnet | `10143` | `0x6724818814927e057a693f4e3A172b6cC1eA690C` |
+| Monad Mainnet | `143` | `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67` |
 
-**Monad:**
-- Testnet: `https://testnet-rpc.monad.xyz`
-- Mainnet: `https://rpc-mainnet.monadinfra.com/rpc/YOUR_API_KEY`
+Before broadcasting, the packaged deploy flow verifies:
 
-## Step 2: Build the Contract
+- `NETWORK` is supported
+- `RPC_URL` resolves to the chain ID implied by `NETWORK`
+- Monad `SWITCHBOARD_ADDRESS` overrides match the canonical address
+- The resolved Switchboard address already has bytecode
+
+## Setup
 
 ```bash
 bun install
 forge build
+cp .env.example .env
 ```
 
-Expected output:
-```
-[⠊] Compiling...
-[⠒] Compiling 1 files with 0.8.22
-[⠢] Solc 0.8.22 finished in 1.23s
-Compiler run successful!
-```
-
-## Step 3: Deploy the Contract
-
-### Option A: Using Foundry Script (Recommended)
-
-#### Monad Testnet
+Minimal `.env`:
 
 ```bash
-forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
-  --rpc-url https://testnet-rpc.monad.xyz \
-  --private-key $PRIVATE_KEY \
-  --broadcast \
-  -vvvv
+PRIVATE_KEY=0xyour_private_key_here
+NETWORK=monad-testnet
+RPC_URL=
+SWITCHBOARD_ADDRESS=
 ```
 
-#### Monad Mainnet
+## Deploy With The Packaged Script
+
+Default deploy:
 
 ```bash
-forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
-  --rpc-url $MONAD_RPC_URL \
-  --private-key $PRIVATE_KEY \
-  --broadcast \
-  -vvvv
-```
-
-#### With Custom Switchboard Address
-
-```bash
-SWITCHBOARD_ADDRESS=0xYOUR_SWITCHBOARD_ADDRESS \
-forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
-  --rpc-url $RPC_URL \
-  --private-key $PRIVATE_KEY \
-  --broadcast \
-  -vvvv
-```
-
-### Option B: Using npm Scripts
-
-```bash
-# Monad Testnet
-bun run deploy:monad-testnet
-
-# Monad Mainnet
-MONAD_RPC_URL=https://... bun run deploy:monad-mainnet
-
-# General deployment
 bun run deploy
 ```
 
-### Option C: Direct Forge Create
+Explicit testnet:
 
 ```bash
-forge create src/SwitchboardPriceConsumer.sol:SwitchboardPriceConsumer \
+bun run deploy:monad-testnet
+```
+
+Explicit mainnet:
+
+```bash
+NETWORK=monad-mainnet bun run deploy
+# or
+bun run deploy:monad-mainnet
+```
+
+The deploy wrapper resolves the correct RPC and Switchboard contract from `NETWORK`. `RPC_URL` is only needed when you want to override the default endpoint for that network.
+
+## Direct Forge Execution
+
+Use this only if you deliberately want to bypass the Bun wrapper. You still need to set `NETWORK` so the Solidity deploy script can enforce the same guardrails.
+
+```bash
+NETWORK=monad-testnet \
+RPC_URL=https://testnet-rpc.monad.xyz \
+forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
   --rpc-url $RPC_URL \
-  --private-key $PRIVATE_KEY \
-  --constructor-args 0x33A5066f65f66161bEb3f827A3e40fce7d7A2e6C
+  --broadcast \
+  -vvvv
 ```
 
-## Step 4: Save Contract Address
-
-After deployment, you'll see output like:
-
-```
-Deploying SwitchboardPriceConsumer...
-Switchboard address: 0x33A5066f65f66161bEb3f827A3e40fce7d7A2e6C
-Deployer: 0x...
-
-SwitchboardPriceConsumer deployed at: 0xABCD1234...
-
-Configuration:
-  Max Price Age: 300 seconds
-  Max Deviation: 1000 bps
-  Owner: 0x...
-
-Next steps:
-1. Save the contract address
-2. Run: CONTRACT_ADDRESS=0xABCD1234... bun scripts/run.ts
-```
-
-**Save the contract address!** You'll need it for the next steps.
+Mainnet:
 
 ```bash
-export CONTRACT_ADDRESS=0xYOUR_DEPLOYED_CONTRACT_ADDRESS
+NETWORK=monad-mainnet \
+RPC_URL=https://rpc.monad.xyz \
+forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
+  --rpc-url $RPC_URL \
+  --broadcast \
+  -vvvv
 ```
 
-## Step 5: Verify the Contract (Optional)
+## After Deployment
 
-### On Block Explorers
-
-#### Monad
+Save the deployed consumer contract address:
 
 ```bash
-# Testnet
-forge verify-contract \
-  --chain-id 10143 \
-  --watch \
-  $CONTRACT_ADDRESS \
-  src/SwitchboardPriceConsumer.sol:SwitchboardPriceConsumer \
-  --constructor-args $(cast abi-encode "constructor(address)" 0x6724818814927e057a693f4e3A172b6cC1eA690C)
-
-# Mainnet
-forge verify-contract \
-  --chain-id 143 \
-  --watch \
-  $CONTRACT_ADDRESS \
-  src/SwitchboardPriceConsumer.sol:SwitchboardPriceConsumer \
-  --constructor-args $(cast abi-encode "constructor(address)" 0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67)
+CONTRACT_ADDRESS=0x_your_deployed_consumer
 ```
 
-## Step 6: Run the Example
+Then run the example flow:
 
 ```bash
-# Complete example with deployment, update, and queries
+CONTRACT_ADDRESS=$CONTRACT_ADDRESS bun run example
+```
+
+Or use the script to deploy a fresh contract and run the full flow in one step:
+
+```bash
 bun run example
 ```
 
+## Verification
+
+```bash
+# Testnet
+CHAIN_ID=10143 CONTRACT_ADDRESS=0x_your_deployed_consumer bun run verify
+
+# Mainnet
+CHAIN_ID=143 CONTRACT_ADDRESS=0x_your_deployed_consumer bun run verify
+```
+
+Use constructor args matching the selected network's Switchboard address when the explorer asks for them.
+
 ## Troubleshooting
 
-### "Insufficient funds for gas"
+### RPC and network mismatch
 
-Ensure your wallet has enough native tokens:
+If you see a chain-ID mismatch error, your `RPC_URL` does not match `NETWORK`. Either:
 
-```bash
-# Check balance
-cast balance $YOUR_ADDRESS --rpc-url $RPC_URL
-```
+- remove `RPC_URL` and use the default for that network
+- or point `RPC_URL` at the correct network
 
-### "Nonce too low"
+### Invalid Switchboard override
 
-Reset your nonce or wait for pending transactions:
+If you see a `SWITCHBOARD_ADDRESS must match NETWORK` error, remove the override unless you are intentionally using the canonical address for that exact Monad network.
 
-```bash
-# Check pending transactions
-cast tx $TX_HASH --rpc-url $RPC_URL
-```
+### No code at contract address
 
-### "Contract creation failed"
+If the runtime script rejects `CONTRACT_ADDRESS`, the address is wrong for the selected network or the deployment failed.
 
-Check:
-1. RPC URL is correct
-2. Private key is valid
-3. Switchboard address is correct for the network
-4. You have sufficient gas
+### Insufficient funds
+
+Check the deployer balance:
 
 ```bash
-# Test RPC connection
-cast block latest --rpc-url $RPC_URL
-
-# Test private key
-cast wallet address --private-key $PRIVATE_KEY
+cast balance $(cast wallet address --private-key $PRIVATE_KEY) --rpc-url $RPC_URL
 ```
-
-### "Invalid Switchboard address"
-
-Verify you're using the correct Switchboard contract for your network:
-
-| Network | Switchboard Address |
-|---------|-------------------|
-| Monad Testnet | `0x6724818814927e057a693f4e3A172b6cC1eA690C` |
-| Monad Mainnet | `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67` |
-
-### Build Errors
-
-```bash
-# Clean and rebuild
-forge clean
-forge build
-
-# Update dependencies
-forge update
-
-# Check Solidity version
-forge --version
-```
-
-## Network-Specific Notes
-
-### Monad
-
-- **Gas**: Monad has unique gas mechanics; monitor usage carefully
-- **Block Time**: Faster than Ethereum; adjust staleness checks accordingly
-- **RPC**: Use official RPC endpoints for best performance
-- **Faucet**: Get testnet MON from Discord or official faucet
-
-> **Note**: For other EVM chains (Arbitrum, Core, etc.), see the [legacy examples](./legacy/) which use the previous Switchboard implementation.
-
-## Configuration After Deployment
-
-### Update Max Price Age
-
-```bash
-cast send $CONTRACT_ADDRESS \
-  "updateConfig(uint256,uint256)" \
-  600 1000 \  # 10 minutes, 10% deviation
-  --rpc-url $RPC_URL \
-  --private-key $PRIVATE_KEY
-```
-
-### Transfer Ownership
-
-```bash
-cast send $CONTRACT_ADDRESS \
-  "transferOwnership(address)" \
-  $NEW_OWNER_ADDRESS \
-  --rpc-url $RPC_URL \
-  --private-key $PRIVATE_KEY
-```
-
-## Testing the Deployment
-
-### 1. Check Contract State
-
-```bash
-# Get max price age
-cast call $CONTRACT_ADDRESS \
-  "maxPriceAge()" \
-  --rpc-url $RPC_URL
-
-# Get max deviation
-cast call $CONTRACT_ADDRESS \
-  "maxDeviationBps()" \
-  --rpc-url $RPC_URL
-
-# Get owner
-cast call $CONTRACT_ADDRESS \
-  "owner()" \
-  --rpc-url $RPC_URL
-```
-
-### 2. Submit Test Update
-
-```bash
-# Run the complete example
-bun scripts/run.ts
-```
-
-### 3. Query Price
-
-```bash
-# Get price for BTC/USD feed
-FEED_ID=0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812
-
-cast call $CONTRACT_ADDRESS \
-  "getPrice(bytes32)" \
-  $FEED_ID \
-  --rpc-url $RPC_URL
-```
-
-## Production Deployment Checklist
-
-- [ ] Contract built and tested locally
-- [ ] Correct Switchboard address for target network
-- [ ] Sufficient gas funds in deployment wallet
-- [ ] RPC endpoint is reliable and fast
-- [ ] Contract verified on block explorer
-- [ ] Configuration parameters set appropriately
-- [ ] Ownership transferred to multisig (if applicable)
-- [ ] Test update submitted successfully
-- [ ] Monitoring set up for price updates
-- [ ] Documentation updated with contract address
-
-## Next Steps
-
-After successful deployment:
-
-1. **Integrate into your DApp**
-   - Use the contract address in your frontend
-   - Set up automated price updates
-   - Monitor for events
-
-2. **Set up monitoring**
-   - Track price updates
-   - Monitor gas usage
-   - Alert on stale prices
-
-3. **Configure parameters**
-   - Adjust `maxPriceAge` for your use case
-   - Set `maxDeviationBps` based on volatility
-   - Consider multi-sig for ownership
-
-## Support
-
-If you encounter issues:
-- 📖 [Switchboard Documentation](https://docs.switchboard.xyz)
-- 💬 [Discord Community](https://discord.gg/TJAv6ZYvPC)
-- 🐛 [GitHub Issues](https://github.com/switchboard-xyz/evm-on-demand/issues)

--- a/evm/price-feeds/README.md
+++ b/evm/price-feeds/README.md
@@ -1,68 +1,106 @@
 # EVM Price Feeds Example
 
-Switchboard price feed consumer example for EVM chains (Ethereum, Monad, Arbitrum, etc.).
+Switchboard price feed consumer example for the current EVM on-demand flow.
 
-## Overview
+## What This Example Covers
 
-This example demonstrates how to integrate Switchboard On-Demand oracle price feeds into a Solidity smart contract. The `SwitchboardPriceConsumer` contract includes:
-
-- Secure price updates with signature verification
-- Staleness checks to prevent old data usage
-- Price deviation validation
-- Multi-feed support
+- Deploying a `SwitchboardPriceConsumer` contract
+- Fetching encoded price updates from Crossbar
+- Reading the required oracle update fee from Switchboard
+- Calling `updatePrices(encoded, [feedId], { value: fee })`
+- Reading the stored on-chain price back from the consumer contract
 
 ## Prerequisites
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
-- [Bun](https://bun.sh/) or Node.js
+- [Bun](https://bun.sh/)
+- A funded wallet for the target network
+
+## Standard Network Switch
+
+This example uses the shared EVM env contract:
+
+- `NETWORK=monad-testnet` or `NETWORK=monad-mainnet`
+- `RPC_URL` optional override
+- `PRIVATE_KEY` required
+- `SWITCHBOARD_ADDRESS` advanced override only
+- `CONTRACT_ADDRESS` optional existing consumer contract
+
+Defaults:
+
+- `NETWORK=monad-testnet`
+- Testnet RPC: `https://testnet-rpc.monad.xyz`
+- Mainnet RPC: `https://rpc.monad.xyz`
+
+The deploy and runtime scripts enforce guardrails before broadcast:
+
+- `NETWORK` must be one of the supported values
+- `RPC_URL` must resolve to the chain ID implied by `NETWORK`
+- Monad `SWITCHBOARD_ADDRESS` overrides must match the canonical address for the selected network
+- Existing `CONTRACT_ADDRESS` values must already have bytecode on-chain
 
 ## Setup
 
 ```bash
 bun install
 forge build
-```
-
-### Configure Environment
-
-> **Security:** Never use `export PRIVATE_KEY=...` or pass private keys as command-line arguments—they appear in shell history and process listings. Use a `.env` file instead.
-
-```bash
 cp .env.example .env
 ```
 
-Edit `.env` with your private key and network configuration. Set `CONTRACT_ADDRESS` only if you want to reuse a consumer you already deployed; otherwise `bun run example` deploys a new one for you.
-
-## Build
+Edit `.env`:
 
 ```bash
-forge build
+PRIVATE_KEY=0xyour_private_key_here
+NETWORK=monad-testnet
+RPC_URL=
+SWITCHBOARD_ADDRESS=
+CONTRACT_ADDRESS=
+FEED_HASH=0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812
 ```
 
 ## Deploy
 
-Deploy to specific networks:
+Use the standard deploy entrypoint:
 
 ```bash
-# Monad Testnet
-bun run deploy:monad-testnet
+bun run deploy
+```
 
-# Monad Mainnet (requires MONAD_RPC_URL env var)
+Monad-specific aliases are thin wrappers around the same deploy flow:
+
+```bash
+bun run deploy:monad-testnet
+NETWORK=monad-mainnet bun run deploy
+# or
 bun run deploy:monad-mainnet
 ```
 
-See [DEPLOYMENT.md](./DEPLOYMENT.md) for detailed deployment instructions.
+## Run The End-To-End Example
 
-## Usage
-
-Run the example script:
+If `CONTRACT_ADDRESS` is unset, the example script deploys a fresh consumer contract with ethers and runs the full flow. If `CONTRACT_ADDRESS` is set, it reuses the deployed contract after verifying bytecode exists there.
 
 ```bash
 bun run example
 ```
 
+Switch to Monad mainnet with one env var:
+
+```bash
+NETWORK=monad-mainnet bun run example
+```
+
+Convert a sample Surge payload to EVM-encoded bytes:
+
+```bash
+bun run surge-convert
+```
+
 ## Test
 
 ```bash
-forge test
+bun run test
 ```
+
+## More Detail
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md) for the deploy-specific runbook and troubleshooting notes.

--- a/evm/price-feeds/bun.lock
+++ b/evm/price-feeds/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "evm-on-demand-example",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.5.1",
+        "@switchboard-xyz/common": "^5.7.0",
         "@switchboard-xyz/on-demand-solidity": "^0.0.4",
         "@types/yargs": "^17.0.33",
         "ethers": "^6.13.1",
-        "yaml": "^2.8.2",
+        "yaml": "^2.8.1",
         "yargs": "^18.0.0",
       },
       "devDependencies": {
@@ -62,7 +62,7 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
 
-    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.5.1", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-0oPooEE/E6sbLfLvW/xiPM0fqnzCh6sARWBz8lW9ABJ1IRpLqd0qmFRfFZlYkyLtaQUlb5mKfe5DrPuoyUWvoA=="],
+    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.7.0", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg=="],
 
     "@switchboard-xyz/on-demand-solidity": ["@switchboard-xyz/on-demand-solidity@0.0.4", "", {}, "sha512-YQmTwDF4je6eFX+XlanWK8P0kRmQfz0ChqyIG60Nc7LurQqeyf5LQF5JcYg/dt64lxYWm2qIdCTZkI/XWFs3Vw=="],
 
@@ -242,7 +242,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 

--- a/evm/price-feeds/deploy/DeploySwitchboardPriceConsumer.s.sol
+++ b/evm/price-feeds/deploy/DeploySwitchboardPriceConsumer.s.sol
@@ -9,40 +9,49 @@ import "../src/SwitchboardPriceConsumer.sol";
  * @notice Deployment script for the SwitchboardPriceConsumer contract
  * 
  * Usage:
- *   # Monad Testnet
- *   forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
- *     --rpc-url https://testnet-rpc.monad.xyz \
- *     --broadcast \
- *     --verify \
- *     -vvvv
- * 
- *   # Monad Mainnet
- *   forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
- *     --rpc-url https://rpc-mainnet.monadinfra.com/rpc/YOUR_KEY \
- *     --broadcast \
- *     --verify \
- *     -vvvv
- * 
- *   # With environment variables
- *   SWITCHBOARD_ADDRESS=0x... forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
+ *   # Preferred: use the packaged wrapper so NETWORK and RPC stay in sync
+ *   bun run deploy
+ *
+ *   # Direct forge execution
+ *   NETWORK=monad-testnet RPC_URL=https://testnet-rpc.monad.xyz forge script \
+ *     deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
  *     --rpc-url $RPC_URL \
  *     --broadcast \
  *     -vvvv
  */
 contract DeploySwitchboardPriceConsumer is Script {
-    // Monad Switchboard addresses
     address constant MONAD_TESTNET_SWITCHBOARD = 0x6724818814927e057a693f4e3A172b6cC1eA690C;
     address constant MONAD_MAINNET_SWITCHBOARD = 0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67;
 
     function run() external {
-        // Get Switchboard address from environment or use default (testnet)
-        address switchboardAddress = vm.envOr("SWITCHBOARD_ADDRESS", MONAD_TESTNET_SWITCHBOARD);
-        
-        console.log("Deploying SwitchboardPriceConsumer...");
-        console.log("Switchboard address:", switchboardAddress);
-        console.log("Deployer:", msg.sender);
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        string memory networkName = vm.envString("NETWORK");
+        (address expectedSwitchboard, uint256 expectedChainId) =
+            resolveNetwork(networkName);
+        address switchboardAddress =
+            vm.envOr("SWITCHBOARD_ADDRESS", expectedSwitchboard);
 
-        vm.startBroadcast();
+        require(
+            switchboardAddress == expectedSwitchboard,
+            "SWITCHBOARD_ADDRESS must match NETWORK"
+        );
+        require(
+            block.chainid == expectedChainId,
+            "RPC chain ID does not match NETWORK"
+        );
+        require(
+            switchboardAddress.code.length > 0,
+            "No code at Switchboard address"
+        );
+
+        address deployer = vm.addr(privateKey);
+
+        console.log("Deploying SwitchboardPriceConsumer...");
+        console.log("Network:", networkName);
+        console.log("Switchboard address:", switchboardAddress);
+        console.log("Deployer:", deployer);
+
+        vm.startBroadcast(privateKey);
 
         SwitchboardPriceConsumer consumer = new SwitchboardPriceConsumer(switchboardAddress);
 
@@ -58,5 +67,29 @@ contract DeploySwitchboardPriceConsumer is Script {
         console.log("Next steps:");
         console.log("1. Save the contract address");
         console.log("2. Run: CONTRACT_ADDRESS=", address(consumer), " bun scripts/run.ts");
+    }
+
+    function resolveNetwork(string memory networkName)
+        internal
+        pure
+        returns (address switchboardAddress, uint256 chainId)
+    {
+        if (equal(networkName, "monad-testnet")) {
+            return (MONAD_TESTNET_SWITCHBOARD, 10143);
+        }
+
+        if (equal(networkName, "monad-mainnet")) {
+            return (MONAD_MAINNET_SWITCHBOARD, 143);
+        }
+
+        revert("Unsupported NETWORK");
+    }
+
+    function equal(string memory a, string memory b)
+        internal
+        pure
+        returns (bool)
+    {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
     }
 }

--- a/evm/price-feeds/package.json
+++ b/evm/price-feeds/package.json
@@ -8,9 +8,9 @@
     "surge-convert": "bun scripts/surgeToEvmConversion.ts",
     "build": "forge build",
     "test": "forge test",
-    "deploy": "forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer --broadcast -vvvv",
-    "deploy:monad-testnet": "forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer --rpc-url https://testnet-rpc.monad.xyz --broadcast -vvvv",
-    "deploy:monad-mainnet": "forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer --rpc-url $MONAD_RPC_URL --broadcast -vvvv",
+    "deploy": "bun scripts/deploy.ts",
+    "deploy:monad-testnet": "NETWORK=monad-testnet bun scripts/deploy.ts",
+    "deploy:monad-mainnet": "NETWORK=monad-mainnet bun scripts/deploy.ts",
     "verify": "forge verify-contract --chain-id $CHAIN_ID --watch $CONTRACT_ADDRESS src/SwitchboardPriceConsumer.sol:SwitchboardPriceConsumer"
   },
   "keywords": [

--- a/evm/price-feeds/package.json
+++ b/evm/price-feeds/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@switchboard-xyz/common": "^5.5.1",
+    "@switchboard-xyz/common": "^5.7.0",
     "@switchboard-xyz/on-demand-solidity": "^0.0.4",
     "@types/yargs": "^17.0.33",
     "ethers": "^6.13.1",

--- a/evm/price-feeds/scripts/deploy.ts
+++ b/evm/price-feeds/scripts/deploy.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env bun
+
+import { MONAD_NETWORKS, runForgeDeploy } from "../../network";
+
+runForgeDeploy({
+  script:
+    "deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer",
+  label: "SwitchboardPriceConsumer",
+  allowedNetworks: MONAD_NETWORKS,
+}).catch((error) => {
+  console.error("\n❌ Error:", error.message || error);
+  process.exit(1);
+});

--- a/evm/price-feeds/scripts/run.ts
+++ b/evm/price-feeds/scripts/run.ts
@@ -10,30 +10,30 @@
  *
  * Prerequisites:
  * - Bun runtime: https://bun.sh
- * - RPC URL for your target network
  * - Private key with native tokens for gas
  *
  * Installation:
  *   bun add ethers @switchboard-xyz/common
  *
  * Environment Variables:
- *   RPC_URL      - EVM RPC endpoint (required)
+ *   NETWORK      - Network name (monad-testnet, monad-mainnet)
+ *   RPC_URL      - Optional RPC override for the selected network
  *   PRIVATE_KEY  - Private key for transactions (required)
- *   NETWORK      - Network name (monad-testnet, monad-mainnet, arbitrum, etc.)
+ *   SWITCHBOARD_ADDRESS - Advanced override only
  *
  * Usage:
  *   # Deploy and run complete example
- *   RPC_URL=https://... PRIVATE_KEY=0x... bun scripts/run.ts
+ *   PRIVATE_KEY=0x... bun scripts/run.ts
  *
  *   # Use existing contract
- *   RPC_URL=https://... PRIVATE_KEY=0x... CONTRACT_ADDRESS=0x... bun scripts/run.ts
+ *   PRIVATE_KEY=0x... CONTRACT_ADDRESS=0x... bun scripts/run.ts
  *
  * Examples:
  *   # Monad Testnet
- *   RPC_URL=https://testnet-rpc.monad.xyz PRIVATE_KEY=0x... NETWORK=monad-testnet bun scripts/run.ts
+ *   PRIVATE_KEY=0x... NETWORK=monad-testnet bun scripts/run.ts
  *
  *   # Monad Mainnet
- *   RPC_URL=https://rpc-mainnet.monadinfra.com/rpc/YOUR_KEY PRIVATE_KEY=0x... NETWORK=monad-mainnet bun scripts/run.ts
+ *   PRIVATE_KEY=0x... NETWORK=monad-mainnet bun scripts/run.ts
  *
  * @author Switchboard Labs
  * @license MIT
@@ -43,43 +43,19 @@ import { ethers } from 'ethers';
 import { CrossbarClient } from '@switchboard-xyz/common';
 import * as fs from 'fs';
 import * as path from 'path';
-
-// ============================================================================
-// Network Configurations
-// ============================================================================
-
-interface NetworkConfig {
-  name: string;
-  chainId: number;
-  explorer: string;
-  switchboard: string;
-  verifier?: string;
-  queue?: string;
-}
-
-const NETWORKS: Record<string, NetworkConfig> = {
-  'monad-testnet': {
-    name: 'Monad Testnet',
-    chainId: 10143,
-    explorer: 'https://testnet.monadscan.io',
-    switchboard: '0x6724818814927e057a693f4e3A172b6cC1eA690C',
-  },
-  'monad-mainnet': {
-    name: 'Monad Mainnet',
-    chainId: 143,
-    explorer: 'https://mainnet-beta.monvision.io',
-    switchboard: '0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67',
-  },
-};
+import {
+  MONAD_NETWORKS,
+  assertContractCode,
+  getValidatedNetwork,
+  type ResolvedNetworkConfig,
+} from '../../network';
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
 const config = {
-  rpcUrl: process.env.RPC_URL || '',
   privateKey: process.env.PRIVATE_KEY || '',
-  network: (process.env.NETWORK || 'monad-testnet') as keyof typeof NETWORKS,
   contractAddress: process.env.CONTRACT_ADDRESS || '',
   
   // Feed configuration
@@ -136,16 +112,18 @@ function formatValue(value: bigint, decimals: number = 18): string {
   return `${whole}.${trimmed}`;
 }
 
-async function fetchFeedData(feedHash: string, networkConfig: NetworkConfig) {
+async function fetchFeedData(
+  feedHash: string,
+  networkConfig: ResolvedNetworkConfig
+) {
   const normalizedHash = normalizeFeedHash(feedHash);
 
   console.log('📡 Fetching feed data from Switchboard Crossbar...');
   console.log(`   Feed: ${normalizedHash}`);
   console.log(`   Chain ID: ${networkConfig.chainId}`);
 
-  const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
-
   try {
+    const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
     const response = await crossbar.fetchEVMResults({
       chainId: networkConfig.chainId,
       aggregatorIds: [normalizedHash],
@@ -179,33 +157,14 @@ async function fetchFeedData(feedHash: string, networkConfig: NetworkConfig) {
       encoded: response.encoded,
     };
   } catch (error: any) {
-    console.warn(`⚠️  Chain-specific Crossbar lookup failed: ${error.message}`);
-    console.warn('   Falling back to the network-agnostic oracle quote endpoint...');
-
-    const response = await crossbar.fetchOracleQuote([normalizedHash], 'mainnet');
-    if (!response.encoded) {
-      throw new Error('Fallback oracle quote did not return encoded data');
-    }
-
-    const latestResult = response.medianResponses?.[0];
-
-    console.log('✅ Feed data retrieved via fallback endpoint:');
-    if (latestResult?.value) {
-      console.log(`   Value: ${formatValue(BigInt(latestResult.value))}`);
-    }
-    console.log(`   Timestamp: ${new Date(response.timestamp * 1000).toISOString()}`);
-    console.log('   Encoded updates: 1');
-
-    return {
-      feedHash: normalizedHash,
-      value: latestResult?.value,
-      timestamp: response.timestamp,
-      encoded: [response.encoded],
-    };
+    throw new Error(`Failed to fetch feed data: ${error.message}`);
   }
 }
 
-async function deployContract(signer: ethers.Wallet, networkConfig: NetworkConfig) {
+async function deployContract(
+  signer: ethers.Wallet,
+  networkConfig: ResolvedNetworkConfig
+) {
   console.log('\n📝 Deploying SwitchboardPriceConsumer...');
   
   // Read the compiled contract
@@ -243,49 +202,39 @@ async function deployContract(signer: ethers.Wallet, networkConfig: NetworkConfi
 async function main() {
   console.log('🚀 Switchboard Price Consumer Example\n');
 
-  // Validate configuration
-  if (!config.rpcUrl) {
-    throw new Error('RPC_URL environment variable is required');
-  }
   if (!config.privateKey) {
     throw new Error('PRIVATE_KEY environment variable is required');
   }
 
-  const networkConfig = NETWORKS[config.network];
-  if (!networkConfig) {
-    throw new Error(`Unknown network: ${config.network}`);
-  }
+  const networkConfig = await getValidatedNetwork({
+    allowedNetworks: MONAD_NETWORKS,
+  });
+  const provider = new ethers.JsonRpcProvider(networkConfig.rpcUrl);
 
   console.log('Configuration:');
   console.log(`  Network: ${networkConfig.name}`);
   console.log(`  Chain ID: ${networkConfig.chainId}`);
-  console.log(`  RPC: ${config.rpcUrl}`);
+  console.log(`  RPC: ${networkConfig.rpcUrl}`);
+  console.log(`  Switchboard: ${networkConfig.switchboard}`);
   console.log(`  Feed: ${config.feedHash}`);
   console.log('');
 
-  // Setup provider and signer
-  const network = new ethers.Network(networkConfig.name, networkConfig.chainId);
-  const provider = new ethers.JsonRpcProvider(config.rpcUrl, network, {
-    staticNetwork: true,
-  });
   const signer = new ethers.Wallet(config.privateKey, provider);
 
   console.log(`👤 Signer: ${signer.address}`);
   const balance = await provider.getBalance(signer.address);
-  console.log(`   Balance: ${ethers.formatEther(balance)} ${networkConfig.name.includes('Monad') ? 'MON' : 'ETH'}\n`);
-
-  const switchboardCode = await provider.getCode(networkConfig.switchboard);
-  if (switchboardCode === '0x') {
-    throw new Error(
-      `No bytecode found at configured Switchboard address ${networkConfig.switchboard} on chain ${networkConfig.chainId}`
-    );
-  }
+  console.log(`   Balance: ${ethers.formatEther(balance)} ${networkConfig.nativeSymbol}\n`);
 
   // Deploy or use existing contract
   let contractAddress = config.contractAddress;
   if (!contractAddress) {
     contractAddress = await deployContract(signer, networkConfig);
   } else {
+    contractAddress = await assertContractCode(
+      networkConfig,
+      contractAddress,
+      'price consumer'
+    );
     console.log(`📋 Using existing contract: ${contractAddress}\n`);
   }
 
@@ -317,7 +266,7 @@ async function main() {
   );
 
   const fee = await switchboard.getFee(feedData.encoded);
-  console.log(`💰 Update fee: ${ethers.formatEther(fee)} ${networkConfig.name.includes('Monad') ? 'MON' : 'ETH'}`);
+  console.log(`💰 Update fee: ${ethers.formatEther(fee)} ${networkConfig.nativeSymbol}`);
 
   console.log('\n📤 Submitting transaction...');
   const feedIdForUpdate = normalizeFeedHash(config.feedHash);

--- a/evm/price-feeds/scripts/surgeToEvmConversion.ts
+++ b/evm/price-feeds/scripts/surgeToEvmConversion.ts
@@ -7,23 +7,22 @@
  *
  * Prerequisites:
  * - Bun runtime: https://bun.sh
- * - Access to Switchboard Surge updates
+ * - `npm install` in this package directory
  *
  * Installation:
- *   bun add @switchboard-xyz/common
+ *   npm install
  *
  * Usage:
  *   # Basic conversion with sample data
- *   bun examples/surgeToEvmConversion.ts
+ *   bun run surge-convert
  *
  *   # With custom surge data (JSON file)
- *   SURGE_DATA_FILE=path/to/surge-data.json bun examples/surgeToEvmConversion.ts
+ *   SURGE_DATA_FILE=path/to/surge-data.json bun run surge-convert
  *
  * @author Switchboard Labs
  * @license MIT
  */
 
-// Import from the local common library since we just added the new functionality
 import { EVMUtils, type SurgeRawGatewayResponse } from '@switchboard-xyz/common';
 import * as fs from 'fs';
 

--- a/evm/randomness/bun.lock
+++ b/evm/randomness/bun.lock
@@ -3,11 +3,10 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "evm-randomness-core",
+      "name": "evm-randomness-example",
       "dependencies": {
         "@switchboard-xyz/common": "^5.5.1",
         "ethers": "^6.16.0",
-        "yaml": "^2.8.2",
       },
     },
   },
@@ -186,7 +185,7 @@
 
     "tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
@@ -199,8 +198,6 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
-
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "@solana/errors/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 

--- a/evm/randomness/bun.lock
+++ b/evm/randomness/bun.lock
@@ -5,8 +5,9 @@
     "": {
       "name": "evm-randomness-example",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.5.1",
+        "@switchboard-xyz/common": "^5.7.0",
         "ethers": "^6.16.0",
+        "yaml": "^2.8.3",
       },
     },
   },
@@ -198,6 +199,8 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "@solana/errors/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 

--- a/evm/randomness/coin-flip/.env.example
+++ b/evm/randomness/coin-flip/.env.example
@@ -1,11 +1,14 @@
 # Private key for signing transactions (with 0x prefix)
 PRIVATE_KEY=0xyour_private_key_here
 
-# RPC URL (defaults to Monad testnet if not set)
-RPC_URL=https://testnet-rpc.monad.xyz
+# Network to use (monad-testnet, monad-mainnet)
+NETWORK=monad-testnet
+
+# RPC URL (optional - uses the default for NETWORK if not set)
+RPC_URL=
+
+# Advanced override only. For Monad, this must match the canonical address for the selected NETWORK.
+SWITCHBOARD_ADDRESS=
 
 # Deployed CoinFlip contract address
 COIN_FLIP_CONTRACT_ADDRESS=0x...
-
-# Optional wager amount (defaults to 0.01)
-WAGER_AMOUNT=0.01

--- a/evm/randomness/coin-flip/README.md
+++ b/evm/randomness/coin-flip/README.md
@@ -1,289 +1,114 @@
-# Switchboard Randomness Example
+# Switchboard Randomness Example: Coin Flip
 
-A coin flip game demonstrating Switchboard's on-chain randomness on EVM chains using Foundry.
+This example shows the standard EVM randomness flow with a simple wagering game:
+
+1. Call `coinFlip()` to create a randomness request on-chain
+2. Read the assigned oracle and settlement timing from the contract
+3. Ask Crossbar for the encoded randomness reveal
+4. Call `settleFlip(encoded)` to verify and use the result on-chain
 
 ## Prerequisites
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 - [Bun](https://bun.sh/)
+- A funded wallet on Monad testnet or Monad mainnet
 
----
+## Standard Network Switch
 
-## Installation
+This example uses the shared EVM env contract:
 
-### 1. Install Dependencies
+- `NETWORK=monad-testnet` or `NETWORK=monad-mainnet`
+- `RPC_URL` optional override
+- `PRIVATE_KEY` required
+- `SWITCHBOARD_ADDRESS` advanced override only
+- `COIN_FLIP_CONTRACT_ADDRESS` required for the runtime script
 
-Install the TypeScript/JavaScript dependencies using Bun:
+Defaults:
+
+- `NETWORK=monad-testnet`
+- Testnet RPC: `https://testnet-rpc.monad.xyz`
+- Mainnet RPC: `https://rpc.monad.xyz`
+
+Guardrails:
+
+- `NETWORK` must be supported
+- `RPC_URL` must match the selected network's chain ID
+- Monad `SWITCHBOARD_ADDRESS` overrides must match the canonical address for the selected network
+- `COIN_FLIP_CONTRACT_ADDRESS` must already contain deployed bytecode before `bun run flip` will continue
+
+> Running this example on mainnet is operationally possible after the network switch, but the game economics are unchanged. A losing flip still burns the wager.
+
+## Setup
 
 ```bash
 bun install
-```
-
-This installs:
-- `@switchboard-xyz/common` — Crossbar client for off-chain randomness resolution
-- `@switchboard-xyz/on-demand-solidity` — Solidity interfaces and libraries for Switchboard
-
-## Forge Remappings
-
-To import Switchboard interfaces and libraries in your Solidity contracts, configure forge remappings.
-
-Create or update `remappings.txt` in your project root:
-
-```txt
-@switchboard-xyz/on-demand-solidity/=node_modules/@switchboard-xyz/on-demand-solidity
-```
-
-This allows you to import Switchboard contracts like so:
-
-```solidity
-import { ISwitchboard } from '@switchboard-xyz/on-demand-solidity/interfaces/ISwitchboard.sol';
-import { SwitchboardTypes } from '@switchboard-xyz/on-demand-solidity/libraries/SwitchboardTypes.sol';
-```
-
----
-
-## Integration Guide
-
-### On-Chain: Smart Contract Integration
-
-The `CoinFlip.sol` contract demonstrates the core randomness flow:
-
-#### 1. Store the Switchboard Contract Reference
-
-```solidity
-import { ISwitchboard } from '@switchboard-xyz/on-demand-solidity/interfaces/ISwitchboard.sol';
-import { SwitchboardTypes } from '@switchboard-xyz/on-demand-solidity/libraries/SwitchboardTypes.sol';
-
-contract CoinFlip {
-    ISwitchboard public switchboard;
-
-    constructor(address _switchboard) {
-        switchboard = ISwitchboard(_switchboard);
-    }
-}
-```
-
-#### 2. Request Randomness
-
-Call `createRandomness()` with a unique ID and the number of random words needed:
-
-```solidity
-function coinFlip() public payable {
-    // Generate a unique randomness ID
-    bytes32 randomnessId = keccak256(abi.encodePacked(block.timestamp));
-    
-    // Request 1 random word from Switchboard
-    switchboard.createRandomness(randomnessId, 1);
-    
-    // Store the randomness ID for later settlement
-    wagers[msg.sender] = Wager({
-        amount: msg.value,
-        user: msg.sender,
-        randomnessId: randomnessId,
-        flipTimestamp: block.timestamp
-    });
-}
-```
-
-#### 3. Settle Randomness
-
-After the randomness is resolved off-chain, settle it on-chain and use the result:
-
-```solidity
-function settleFlip(bytes calldata encodedRandomness) public {
-    // Settle the randomness on-chain
-    switchboard.settleRandomness(encodedRandomness);
-
-    // Retrieve the wager and randomness
-    Wager memory wager = wagers[msg.sender];
-    SwitchboardTypes.Randomness memory randomness = switchboard.getRandomness(wager.randomnessId);
-    
-    // Ensure randomness is resolved
-    require(randomness.value != 0, "Randomness not resolved");
-
-    // Use the random value (e.g., coin flip: even = win)
-    if (uint256(randomness.value) % 2 == 0) {
-        (bool success, ) = wager.user.call{value: wager.amount * 2}("");
-        require(success, "Transfer failed");
-    }
-
-    delete wagers[msg.sender];
-}
-```
-
-#### 4. Helper Functions for Off-Chain Coordination
-
-Expose data needed by the off-chain component to resolve randomness:
-
-```solidity
-function getWagerRandomnessId(address user) public view returns (bytes32) {
-    return wagers[user].randomnessId;
-}
-
-function getWagerData(address user) public view returns (
-    address oracle, 
-    uint256 rollTimestamp, 
-    uint256 minSettlementDelay
-) {
-    SwitchboardTypes.Randomness memory randomness = switchboard.getRandomness(wagers[user].randomnessId);
-    return (randomness.oracle, randomness.rollTimestamp, randomness.minSettlementDelay);
-}
-```
-
----
-
-### Off-Chain: Resolving Randomness with Crossbar
-
-The `scripts/flipCoin.ts` script demonstrates the complete off-chain flow:
-
-#### 1. Setup the Crossbar Client
-
-```typescript
-import { ethers } from "ethers";
-import { CrossbarClient } from "@switchboard-xyz/common";
-
-const provider = new ethers.JsonRpcProvider("https://testnet-rpc.monad.xyz");
-const wallet = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
-
-// Initialize the Crossbar client
-const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
-```
-
-#### 2. Request Randomness On-Chain
-
-```typescript
-const coinFlipContract = new ethers.Contract(
-    COIN_FLIP_CONTRACT_ADDRESS,
-    coinFlipAbi,
-    wallet
-);
-
-// Send the coin flip transaction (requests randomness)
-const tx = await coinFlipContract.coinFlip({ value: ethers.parseEther("0.01") });
-await tx.wait();
-```
-
-#### 3. Fetch Wager Data for Resolution
-
-```typescript
-// Get the randomness ID stored on-chain
-const wagerRandomnessId = await coinFlipContract.getWagerRandomnessId(wallet.address);
-
-// Get oracle assignment and timing data
-const wagerData = await coinFlipContract.getWagerData(wallet.address);
-```
-
-#### 4. Resolve Randomness via Crossbar
-
-```typescript
-// Get the chain ID dynamically from the provider
-const network = await provider.getNetwork();
-const chainId = Number(network.chainId);
-
-const { encoded } = await crossbar.resolveEVMRandomness({
-    chainId,
-    randomnessId: wagerRandomnessId,
-    timestamp: Number(wagerData.rollTimestamp),
-    minStalenessSeconds: Number(wagerData.minSettlementDelay),
-    oracle: wagerData.oracle,
-});
-```
-
-#### 5. Settle On-Chain
-
-```typescript
-// Submit the encoded randomness to settle the flip
-const tx2 = await coinFlipContract.settleFlip(encoded);
-await tx2.wait();
-console.log("Flip settled:", tx2.hash);
-```
-
----
-
-## Running the Example
-
-### 1. Build the Contracts
-
-```bash
 forge build
-```
-
-### 2. Configure Environment
-
-> **Security:** Never use `export PRIVATE_KEY=...` or pass private keys as command-line arguments—they appear in shell history and process listings. Use a `.env` file instead.
-
-```bash
 cp .env.example .env
 ```
 
-Edit `.env` with your private key and RPC URL. The example defaults to Monad testnet and uses a `0.01` native-token wager.
-
-### 3. Deploy the Contract
+Edit `.env`:
 
 ```bash
-source .env
-forge script deploy/CoinFlip.s.sol:CoinFlipScript \
-    --rpc-url $RPC_URL \
-    --private-key $PRIVATE_KEY \
-    --broadcast
-
-# Add a small bankroll so wins can be paid out
-cast send $COIN_FLIP_CONTRACT_ADDRESS --rpc-url $RPC_URL --private-key $PRIVATE_KEY --value 0.05ether
+PRIVATE_KEY=0xyour_private_key_here
+NETWORK=monad-testnet
+RPC_URL=
+SWITCHBOARD_ADDRESS=
+COIN_FLIP_CONTRACT_ADDRESS=0x...
 ```
 
-### 4. Run the Coin Flip Script
+## Deploy
 
-After deploying, add the contract address to your `.env` file, then run:
+Use the packaged deploy wrapper:
+
+```bash
+bun run deploy
+```
+
+Switch to mainnet with one env var:
+
+```bash
+NETWORK=monad-mainnet bun run deploy
+```
+
+Aliases are also available:
+
+```bash
+bun run deploy:monad-testnet
+bun run deploy:monad-mainnet
+```
+
+After deployment, save the emitted contract address into `COIN_FLIP_CONTRACT_ADDRESS`.
+
+## Run The Coin Flip
 
 ```bash
 bun run flip
 ```
 
----
+The runtime script will:
 
-## Foundry Commands
+- verify the selected `NETWORK`
+- verify the RPC chain ID
+- verify the Switchboard contract exists on that chain
+- verify `COIN_FLIP_CONTRACT_ADDRESS` exists on that chain
+- submit the flip
+- resolve the randomness through Crossbar
+- settle the result on-chain
 
-### Build
-
-```bash
-forge build
-```
-
-### Test
-
-```bash
-forge test
-```
-
-### Format
+## Test
 
 ```bash
-forge fmt
+bun run test
 ```
 
-### Gas Snapshots
+## Direct Forge Deployment
+
+If you need raw Foundry instead of the Bun wrapper, keep the same env contract:
 
 ```bash
-forge snapshot
+NETWORK=monad-testnet \
+RPC_URL=https://testnet-rpc.monad.xyz \
+forge script deploy/CoinFlip.s.sol:CoinFlipScript \
+  --rpc-url $RPC_URL \
+  --broadcast
 ```
-
-### Local Node (Anvil)
-
-```bash
-anvil
-```
-
-### Help
-
-```bash
-forge --help
-anvil --help
-cast --help
-```
-
----
-
-## Documentation
-
-- [Foundry Book](https://book.getfoundry.sh/)
-- [Switchboard Documentation](https://docs.switchboard.xyz/)

--- a/evm/randomness/coin-flip/bun.lock
+++ b/evm/randomness/coin-flip/bun.lock
@@ -5,9 +5,10 @@
     "": {
       "name": "randomness",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.5.1",
+        "@switchboard-xyz/common": "^5.7.0",
         "@switchboard-xyz/on-demand-solidity": "^1.1.0",
         "ethers": "^6.15.0",
+        "yaml": "^2.8.3",
       },
     },
   },
@@ -52,7 +53,7 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
 
-    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.5.1", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-0oPooEE/E6sbLfLvW/xiPM0fqnzCh6sARWBz8lW9ABJ1IRpLqd0qmFRfFZlYkyLtaQUlb5mKfe5DrPuoyUWvoA=="],
+    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.7.0", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg=="],
 
     "@switchboard-xyz/on-demand-solidity": ["@switchboard-xyz/on-demand-solidity@1.1.0", "", {}, "sha512-wXbwZsPb6Kq5HCAI2hmj2zkdEj00+wD1EQ78YUWwBMupXhWu9TAs9MFNXVBifOo01s5sAY0iqG2GSyPybo0paQ=="],
 
@@ -201,6 +202,8 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 

--- a/evm/randomness/coin-flip/bun.lock
+++ b/evm/randomness/coin-flip/bun.lock
@@ -7,8 +7,7 @@
       "dependencies": {
         "@switchboard-xyz/common": "^5.5.1",
         "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-        "ethers": "^6.16.0",
-        "yaml": "^2.8.2",
+        "ethers": "^6.15.0",
       },
     },
   },
@@ -202,8 +201,6 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
-
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 

--- a/evm/randomness/coin-flip/deploy/CoinFlip.s.sol
+++ b/evm/randomness/coin-flip/deploy/CoinFlip.s.sol
@@ -13,18 +13,58 @@ contract CoinFlipScript is Script {
     function setUp() public {}
 
     function run() public {
-        address switchboardAddress = vm.envOr(
-            "SWITCHBOARD_ADDRESS",
-            MONAD_TESTNET_SWITCHBOARD
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        string memory networkName = vm.envString("NETWORK");
+        (address expectedSwitchboard, uint256 expectedChainId) =
+            resolveNetwork(networkName);
+        address switchboardAddress =
+            vm.envOr("SWITCHBOARD_ADDRESS", expectedSwitchboard);
+
+        require(
+            switchboardAddress == expectedSwitchboard,
+            "SWITCHBOARD_ADDRESS must match NETWORK"
+        );
+        require(
+            block.chainid == expectedChainId,
+            "RPC chain ID does not match NETWORK"
+        );
+        require(
+            switchboardAddress.code.length > 0,
+            "No code at Switchboard address"
         );
 
-        vm.startBroadcast();
+        vm.startBroadcast(privateKey);
 
         coinFlip = new CoinFlip(switchboardAddress);
         
         console.log("CoinFlip contract deployed to:", address(coinFlip));
+        console.log("Network:", networkName);
         console.log("Switchboard contract:", switchboardAddress);
 
         vm.stopBroadcast();
+    }
+
+    function resolveNetwork(string memory networkName)
+        internal
+        pure
+        returns (address switchboardAddress, uint256 chainId)
+    {
+        if (equal(networkName, "monad-testnet")) {
+            return (MONAD_TESTNET_SWITCHBOARD, 10143);
+        }
+
+        if (equal(networkName, "monad-mainnet")) {
+            return (MONAD_MAINNET_SWITCHBOARD, 143);
+        }
+
+        revert("Unsupported NETWORK");
+    }
+
+    function equal(string memory a, string memory b)
+        internal
+        pure
+        returns (bool)
+    {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
     }
 }

--- a/evm/randomness/coin-flip/package-lock.json
+++ b/evm/randomness/coin-flip/package-lock.json
@@ -1,17 +1,24 @@
 {
-  "name": "randomness",
+  "name": "coin-flip",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "randomness",
+      "name": "coin-flip",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@switchboard-xyz/common": "^5.5.1",
-        "@switchboard-xyz/on-demand-solidity": "^1.1.0"
+        "@switchboard-xyz/on-demand-solidity": "^1.1.0",
+        "ethers": "^6.15.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
@@ -283,6 +290,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
@@ -579,6 +592,100 @@
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/eventemitter3": {

--- a/evm/randomness/coin-flip/package-lock.json
+++ b/evm/randomness/coin-flip/package-lock.json
@@ -9,9 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.5.1",
+        "@switchboard-xyz/common": "^5.7.0",
         "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-        "ethers": "^6.15.0"
+        "ethers": "^6.15.0",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -233,9 +234,9 @@
       }
     },
     "node_modules/@switchboard-xyz/common": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.5.1.tgz",
-      "integrity": "sha512-0oPooEE/E6sbLfLvW/xiPM0fqnzCh6sARWBz8lW9ABJ1IRpLqd0qmFRfFZlYkyLtaQUlb5mKfe5DrPuoyUWvoA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.7.0.tgz",
+      "integrity": "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg==",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.2",
@@ -1228,6 +1229,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/evm/randomness/coin-flip/package.json
+++ b/evm/randomness/coin-flip/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "forge build",
+    "deploy": "bun run scripts/deploy.ts",
+    "deploy:monad-testnet": "NETWORK=monad-testnet bun run scripts/deploy.ts",
+    "deploy:monad-mainnet": "NETWORK=monad-mainnet bun run scripts/deploy.ts",
     "flip": "bun run scripts/flipCoin.ts",
     "test": "forge test"
   },
@@ -13,7 +16,6 @@
   "dependencies": {
     "@switchboard-xyz/common": "^5.5.1",
     "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-    "ethers": "^6.16.0",
-    "yaml": "^2.8.2"
+    "ethers": "^6.15.0"
   }
 }

--- a/evm/randomness/coin-flip/package.json
+++ b/evm/randomness/coin-flip/package.json
@@ -14,8 +14,9 @@
   "author": "Switchboard Labs",
   "license": "MIT",
   "dependencies": {
-    "@switchboard-xyz/common": "^5.5.1",
+    "@switchboard-xyz/common": "^5.7.0",
     "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-    "ethers": "^6.15.0"
+    "ethers": "^6.15.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/evm/randomness/coin-flip/scripts/deploy.ts
+++ b/evm/randomness/coin-flip/scripts/deploy.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bun
+
+import { MONAD_NETWORKS, runForgeDeploy } from "../../../network";
+
+runForgeDeploy({
+  script: "deploy/CoinFlip.s.sol:CoinFlipScript",
+  label: "CoinFlip",
+  allowedNetworks: MONAD_NETWORKS,
+}).catch((error) => {
+  console.error("\n❌ Error:", error.message || error);
+  process.exit(1);
+});

--- a/evm/randomness/coin-flip/scripts/flipCoin.ts
+++ b/evm/randomness/coin-flip/scripts/flipCoin.ts
@@ -1,32 +1,35 @@
 import { ethers } from "ethers";
 import { CrossbarClient } from "@switchboard-xyz/common";
-import { sleep } from "./utils";
-
-const DEFAULT_RPC_URL = "https://testnet-rpc.monad.xyz";
-const DEFAULT_NATIVE_SYMBOL = "MON";
-const DEFAULT_WAGER = "0.01";
-const SETTLEMENT_BUFFER_SECONDS = 10;
+import {
+    MONAD_NETWORKS,
+    getValidatedNetwork,
+    requireDeployedContract,
+    requirePrivateKey,
+} from "../../../network";
 
 async function main() {
-
-    const privateKey = process.env.PRIVATE_KEY;
-    if (!privateKey) {
-        throw new Error("PRIVATE_KEY is not set");
-    }
-
-    const rpcUrl = process.env.RPC_URL || DEFAULT_RPC_URL;
-    const nativeSymbol = process.env.NATIVE_SYMBOL || DEFAULT_NATIVE_SYMBOL;
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const privateKey = requirePrivateKey();
+    const config = await getValidatedNetwork({
+        allowedNetworks: MONAD_NETWORKS,
+    });
+    const provider = new ethers.JsonRpcProvider(config.rpcUrl);
     const wallet = new ethers.Wallet(privateKey, provider);
 
     // Initialize Crossbar
     const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
 
-    const COIN_FLIP_CONTRACT_ADDRESS = process.env.COIN_FLIP_CONTRACT_ADDRESS;
+    const COIN_FLIP_CONTRACT_ADDRESS = await requireDeployedContract(
+        config,
+        "COIN_FLIP_CONTRACT_ADDRESS",
+        "CoinFlip"
+    );
 
-    if (!COIN_FLIP_CONTRACT_ADDRESS) {
-        throw new Error("COIN_FLIP_CONTRACT_ADDRESS is not set");
-    }
+    console.log(`Network: ${config.name} (${config.key})`);
+    console.log(`Chain ID: ${config.chainId}`);
+    console.log(`RPC URL: ${config.rpcUrl}`);
+    console.log(`Switchboard: ${config.switchboard}`);
+    console.log(`CoinFlip: ${COIN_FLIP_CONTRACT_ADDRESS}`);
+    console.log(`Wallet: ${wallet.address}`);
 
     // CoinFlip ABI
     const coinFlipAbi = [
@@ -41,40 +44,22 @@ async function main() {
     // CoinFlip contract
     const coinFlipContract = new ethers.Contract(COIN_FLIP_CONTRACT_ADDRESS, coinFlipAbi, wallet);
 
-    let wagerRandomnessId: string = await coinFlipContract.getWagerRandomnessId(wallet.address);
+    // Run the coin flip
+    const tx = await coinFlipContract.coinFlip({ value: ethers.parseEther("1") });
+    await tx.wait();
+    console.log("Coin flip transaction sent", tx);
 
-    if (wagerRandomnessId === ethers.ZeroHash) {
-        const wagerAmount = process.env.WAGER_AMOUNT || DEFAULT_WAGER;
-        const tx = await coinFlipContract.coinFlip({ value: ethers.parseEther(wagerAmount) });
-        await tx.wait();
-        console.log("Coin flip transaction sent", tx);
-
-        wagerRandomnessId = await coinFlipContract.getWagerRandomnessId(wallet.address);
-        console.log("Wager randomness ID:", wagerRandomnessId);
-    } else {
-        console.log("Found pending wager, resuming settlement:", wagerRandomnessId);
-    }
+    // Get the wager randomness ID
+    const wagerRandomnessId: string = await coinFlipContract.getWagerRandomnessId(wallet.address);
+    console.log("Wager randomness ID:", wagerRandomnessId);
+    
 
     const wagerData = await coinFlipContract.getWagerData(wallet.address);
     console.log("Wager data:", wagerData);
 
-    const settlementTime =
-        Number(wagerData.rollTimestamp) + Number(wagerData.minSettlementDelay);
-    const now = Math.floor(Date.now() / 1000);
-    const waitSeconds = Math.max(0, settlementTime - now + SETTLEMENT_BUFFER_SECONDS);
-
-    if (waitSeconds > 0) {
-        console.log(`Waiting ${waitSeconds}s for randomness settlement window...`);
-        await sleep(waitSeconds * 1000);
-    }
-
-    // Get the chain ID dynamically from the provider
-    const network = await provider.getNetwork();
-    const chainId = Number(network.chainId);
-
     // Get the randomness from Switchboard
     const { encoded } = await crossbar.resolveEVMRandomness({
-        chainId,
+        chainId: config.chainId,
         randomnessId: wagerRandomnessId,
         timestamp: Number(wagerData.rollTimestamp),
         minStalenessSeconds: Number(wagerData.minSettlementDelay),
@@ -104,7 +89,7 @@ async function main() {
         console.log("\n========================================");
         if (won) {
             console.log("🎉 YOU WON!");
-            console.log(`💰 Payout: ${ethers.formatEther(payout)} ${nativeSymbol}`);
+            console.log(`💰 Payout: ${ethers.formatEther(payout)} ${config.nativeSymbol}`);
         } else {
             console.log("😔 YOU LOST");
             console.log("💸 Better luck next time!");
@@ -117,4 +102,7 @@ async function main() {
     }
 }
 
-main();
+main().catch((error) => {
+    console.error("Error:", error.message || error);
+    process.exit(1);
+});

--- a/evm/randomness/package.json
+++ b/evm/randomness/package.json
@@ -1,15 +1,14 @@
 {
-  "name": "evm-randomness-core",
-  "version": "1.0.0",
-  "description": "Core Switchboard EVM randomness example",
+  "name": "evm-randomness-example",
+  "private": true,
   "type": "module",
   "scripts": {
-    "example": "bun randomness.ts"
+    "example": "bun randomness.ts",
+    "example:monad-mainnet": "NETWORK=monad-mainnet bun randomness.ts",
+    "example:hyperliquid-mainnet": "NETWORK=hyperliquid-mainnet bun randomness.ts"
   },
-  "license": "MIT",
   "dependencies": {
     "@switchboard-xyz/common": "^5.5.1",
-    "ethers": "^6.16.0",
-    "yaml": "^2.8.2"
+    "ethers": "^6.16.0"
   }
 }

--- a/evm/randomness/package.json
+++ b/evm/randomness/package.json
@@ -8,7 +8,8 @@
     "example:hyperliquid-mainnet": "NETWORK=hyperliquid-mainnet bun randomness.ts"
   },
   "dependencies": {
-    "@switchboard-xyz/common": "^5.5.1",
-    "ethers": "^6.16.0"
+    "@switchboard-xyz/common": "^5.7.0",
+    "ethers": "^6.16.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/evm/randomness/pancake-stacker/.env.example
+++ b/evm/randomness/pancake-stacker/.env.example
@@ -1,8 +1,14 @@
 # Private key for signing transactions (with 0x prefix)
 PRIVATE_KEY=0xyour_private_key_here
 
+# Network to use (monad-testnet, monad-mainnet)
+NETWORK=monad-testnet
+
+# RPC URL (optional - uses the default for NETWORK if not set)
+RPC_URL=
+
+# Advanced override only. For Monad, this must match the canonical address for the selected NETWORK.
+SWITCHBOARD_ADDRESS=
+
 # Deployed PancakeStacker contract address
 PANCAKE_STACKER_CONTRACT_ADDRESS=0x...
-
-# RPC URL (optional - defaults to Monad testnet)
-RPC_URL=https://testnet-rpc.monad.xyz

--- a/evm/randomness/pancake-stacker/README.md
+++ b/evm/randomness/pancake-stacker/README.md
@@ -1,200 +1,90 @@
 # Switchboard Randomness Example: Pancake Stacker
 
-A pancake stacking game demonstrating Switchboard's on-chain randomness on EVM chains using Foundry. Stack pancakes by flipping them onto your pile - each flip has a 2/3 chance to land!
+Pancake Stacker is a simple randomness game:
 
-## How It Works
+1. `flipPancake()` requests on-chain randomness
+2. The client resolves the assigned oracle response through Crossbar
+3. `catchPancake(encoded)` settles the randomness and updates the stack
 
-1. **Flip a pancake** - Request on-chain randomness from Switchboard
-2. **Catch the pancake** - Settle the randomness and see if it lands
-3. **Build your stack** - Each successful flip adds to your stack height
-4. **Don't drop it!** - A failed flip (1/3 chance) knocks over your entire stack
+Each flip has a `2/3` chance to land and a `1/3` chance to reset the stack.
 
 ## Prerequisites
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 - [Bun](https://bun.sh/)
+- A funded wallet on Monad testnet or Monad mainnet
 
----
+## Standard Network Switch
 
-## Installation
+This example uses the shared EVM env contract:
 
-### 1. Install Dependencies
+- `NETWORK=monad-testnet` or `NETWORK=monad-mainnet`
+- `RPC_URL` optional override
+- `PRIVATE_KEY` required
+- `SWITCHBOARD_ADDRESS` advanced override only
+- `PANCAKE_STACKER_CONTRACT_ADDRESS` required for the runtime script
+
+Defaults:
+
+- `NETWORK=monad-testnet`
+- Testnet RPC: `https://testnet-rpc.monad.xyz`
+- Mainnet RPC: `https://rpc.monad.xyz`
+
+Guardrails:
+
+- `NETWORK` must be supported
+- `RPC_URL` must match the selected chain
+- Monad `SWITCHBOARD_ADDRESS` overrides must match the canonical address for the selected network
+- `PANCAKE_STACKER_CONTRACT_ADDRESS` must already contain deployed bytecode before `bun run flip` will continue
+
+## Setup
 
 ```bash
 bun install
-```
-
-This installs:
-- `@switchboard-xyz/common` — Crossbar client for off-chain randomness resolution
-- `@switchboard-xyz/on-demand-solidity` — Solidity interfaces and libraries for Switchboard
-
-## Forge Remappings
-
-To import Switchboard interfaces in your Solidity contracts, configure forge remappings.
-
-`remappings.txt`:
-```txt
-@switchboard-xyz/on-demand-solidity/=node_modules/@switchboard-xyz/on-demand-solidity
-```
-
----
-
-## Integration Guide
-
-### On-Chain: Smart Contract Integration
-
-The `PancakeStacker.sol` contract demonstrates the core randomness flow:
-
-#### 1. Store the Switchboard Contract Reference
-
-```solidity
-import { ISwitchboard } from '@switchboard-xyz/on-demand-solidity/interfaces/ISwitchboard.sol';
-import { SwitchboardTypes } from '@switchboard-xyz/on-demand-solidity/libraries/SwitchboardTypes.sol';
-
-contract PancakeStacker {
-    ISwitchboard public switchboard;
-
-    constructor(address _switchboard) {
-        require(_switchboard != address(0), "Invalid switchboard address");
-        switchboard = ISwitchboard(_switchboard);
-    }
-}
-```
-
-#### 2. Request Randomness
-
-```solidity
-function flipPancake() public {
-    require(pendingFlips[msg.sender] == bytes32(0), "Already have pending flip");
-
-    // Generate unique randomness ID
-    bytes32 randomnessId = keccak256(abi.encodePacked(msg.sender, blockhash(block.number - 1)));
-
-    // Request randomness with 1 second settlement delay
-    switchboard.createRandomness(randomnessId, 1);
-
-    pendingFlips[msg.sender] = randomnessId;
-    emit PancakeFlipRequested(msg.sender, randomnessId);
-}
-```
-
-#### 3. Settle Randomness and Apply Game Logic
-
-```solidity
-function catchPancake(bytes calldata encodedRandomness) public {
-    bytes32 randomnessId = pendingFlips[msg.sender];
-    require(randomnessId != bytes32(0), "No pending flip");
-
-    // Clear pending flip before external calls (CEI pattern)
-    delete pendingFlips[msg.sender];
-
-    try switchboard.settleRandomness(encodedRandomness) {
-        SwitchboardTypes.Randomness memory randomness = switchboard.getRandomness(randomnessId);
-
-        // Verify randomness ID matches
-        require(randomness.randId == randomnessId, "Randomness ID mismatch");
-
-        // 2/3 chance to land, 1/3 chance to knock over
-        bool landed = uint256(randomness.value) % 3 < 2;
-
-        if (landed) {
-            stackHeight[msg.sender]++;
-            emit PancakeLanded(msg.sender, stackHeight[msg.sender]);
-        } else {
-            stackHeight[msg.sender] = 0;
-            emit StackKnockedOver(msg.sender);
-        }
-    } catch {
-        stackHeight[msg.sender] = 0;
-        emit StackKnockedOver(msg.sender);
-        emit SettlementFailed(msg.sender);
-    }
-}
-```
-
----
-
-### Off-Chain: Resolving Randomness with Crossbar
-
-The `scripts/stackPancake.ts` script demonstrates the complete flow:
-
-```typescript
-import { ethers } from "ethers";
-import { CrossbarClient } from "@switchboard-xyz/common";
-
-// Initialize provider and crossbar
-const rpcUrl = process.env.RPC_URL || "https://testnet-rpc.monad.xyz";
-const provider = new ethers.JsonRpcProvider(rpcUrl);
-const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
-
-// 1. Request randomness on-chain
-await contract.flipPancake();
-
-// 2. Get flip data for resolution
-const flipData = await contract.getFlipData(wallet.address);
-
-// 3. Get chain ID dynamically
-const network = await provider.getNetwork();
-const chainId = Number(network.chainId);
-
-// 4. Resolve via Crossbar
-const { encoded } = await crossbar.resolveEVMRandomness({
-    chainId,
-    randomnessId: flipData.randomnessId,
-    timestamp: Number(flipData.rollTimestamp),
-    minStalenessSeconds: Number(flipData.minSettlementDelay),
-    oracle: flipData.oracle,
-});
-
-// 5. Settle on-chain
-await contract.catchPancake(encoded);
-```
-
----
-
-## Running the Example
-
-### 1. Build the Contracts
-
-```bash
 forge build
-```
-
-### 2. Configure Environment
-
-> **Security:** Never use `export PRIVATE_KEY=...` or pass private keys as command-line arguments—they appear in shell history and process listings. Use a `.env` file instead.
-
-```bash
 cp .env.example .env
 ```
 
-Edit `.env` with your private key and RPC URL. The script defaults to Monad testnet.
-
-### 3. Deploy the Contract
+Edit `.env`:
 
 ```bash
-source .env
-forge script deploy/PancakeStacker.s.sol:PancakeStackerScript \
-    --rpc-url $RPC_URL \
-    --private-key $PRIVATE_KEY \
-    --broadcast
+PRIVATE_KEY=0xyour_private_key_here
+NETWORK=monad-testnet
+RPC_URL=
+SWITCHBOARD_ADDRESS=
+PANCAKE_STACKER_CONTRACT_ADDRESS=0x...
 ```
 
-### 4. Run the Pancake Stacking Script
+## Deploy
 
-After deploying, add the contract address to your `.env` file, then run:
+```bash
+bun run deploy
+```
+
+Switch to mainnet with one env var:
+
+```bash
+NETWORK=monad-mainnet bun run deploy
+```
+
+Aliases are also available:
+
+```bash
+bun run deploy:monad-testnet
+bun run deploy:monad-mainnet
+```
+
+After deployment, save the emitted contract address into `PANCAKE_STACKER_CONTRACT_ADDRESS`.
+
+## Run The CLI Flow
 
 ```bash
 bun run flip
 ```
 
----
+The CLI script validates the network selection, RPC chain ID, Switchboard contract, and target contract address before it submits any transactions.
 
-## Web UI
-
-A browser-based UI is included for interacting with the deployed contract.
-
-### Running the UI
+## Run The Web UI
 
 ```bash
 bun start
@@ -202,17 +92,22 @@ bun start
 
 Then open [http://localhost:3000](http://localhost:3000).
 
-### Using the UI
+The browser UI lets you choose the RPC endpoint directly. The `NETWORK` switch standardization applies to the CLI deploy and runtime scripts.
 
-1. Click "Connect Wallet" (MetaMask or compatible wallet)
-2. Click "Flip Pancake" to request randomness
-3. Wait for the randomness to resolve
-4. Click "Catch!" to settle and see if your pancake lands
-5. Keep stacking to build the highest tower!
+## Test
 
----
+```bash
+bun run test
+```
 
-## Documentation
+## Direct Forge Deployment
 
-- [Foundry Book](https://book.getfoundry.sh/)
-- [Switchboard Documentation](https://docs.switchboard.xyz/)
+If you need raw Foundry instead of the Bun wrapper:
+
+```bash
+NETWORK=monad-testnet \
+RPC_URL=https://testnet-rpc.monad.xyz \
+forge script deploy/PancakeStacker.s.sol:PancakeStackerScript \
+  --rpc-url $RPC_URL \
+  --broadcast
+```

--- a/evm/randomness/pancake-stacker/bun.lock
+++ b/evm/randomness/pancake-stacker/bun.lock
@@ -5,9 +5,10 @@
     "": {
       "name": "randomness",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.5.1",
+        "@switchboard-xyz/common": "^5.7.0",
         "@switchboard-xyz/on-demand-solidity": "^1.1.0",
         "ethers": "^6.15.0",
+        "yaml": "^2.8.3",
       },
     },
   },
@@ -52,7 +53,7 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
 
-    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.5.1", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-0oPooEE/E6sbLfLvW/xiPM0fqnzCh6sARWBz8lW9ABJ1IRpLqd0qmFRfFZlYkyLtaQUlb5mKfe5DrPuoyUWvoA=="],
+    "@switchboard-xyz/common": ["@switchboard-xyz/common@5.7.0", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0" } }, "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg=="],
 
     "@switchboard-xyz/on-demand-solidity": ["@switchboard-xyz/on-demand-solidity@1.1.0", "", {}, "sha512-wXbwZsPb6Kq5HCAI2hmj2zkdEj00+wD1EQ78YUWwBMupXhWu9TAs9MFNXVBifOo01s5sAY0iqG2GSyPybo0paQ=="],
 
@@ -201,6 +202,8 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 

--- a/evm/randomness/pancake-stacker/bun.lock
+++ b/evm/randomness/pancake-stacker/bun.lock
@@ -7,8 +7,7 @@
       "dependencies": {
         "@switchboard-xyz/common": "^5.5.1",
         "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-        "ethers": "^6.16.0",
-        "yaml": "^2.8.2",
+        "ethers": "^6.15.0",
       },
     },
   },
@@ -202,8 +201,6 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
-
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 

--- a/evm/randomness/pancake-stacker/deploy/PancakeStacker.s.sol
+++ b/evm/randomness/pancake-stacker/deploy/PancakeStacker.s.sol
@@ -13,18 +13,58 @@ contract PancakeStackerScript is Script {
     function setUp() public {}
 
     function run() public {
-        address switchboardAddress = vm.envOr(
-            "SWITCHBOARD_ADDRESS",
-            MONAD_TESTNET_SWITCHBOARD
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        string memory networkName = vm.envString("NETWORK");
+        (address expectedSwitchboard, uint256 expectedChainId) =
+            resolveNetwork(networkName);
+        address switchboardAddress =
+            vm.envOr("SWITCHBOARD_ADDRESS", expectedSwitchboard);
+
+        require(
+            switchboardAddress == expectedSwitchboard,
+            "SWITCHBOARD_ADDRESS must match NETWORK"
+        );
+        require(
+            block.chainid == expectedChainId,
+            "RPC chain ID does not match NETWORK"
+        );
+        require(
+            switchboardAddress.code.length > 0,
+            "No code at Switchboard address"
         );
 
-        vm.startBroadcast();
+        vm.startBroadcast(privateKey);
 
         pancakeStacker = new PancakeStacker(switchboardAddress);
 
         console.log("PancakeStacker contract deployed to:", address(pancakeStacker));
+        console.log("Network:", networkName);
         console.log("Switchboard contract:", switchboardAddress);
 
         vm.stopBroadcast();
+    }
+
+    function resolveNetwork(string memory networkName)
+        internal
+        pure
+        returns (address switchboardAddress, uint256 chainId)
+    {
+        if (equal(networkName, "monad-testnet")) {
+            return (MONAD_TESTNET_SWITCHBOARD, 10143);
+        }
+
+        if (equal(networkName, "monad-mainnet")) {
+            return (MONAD_MAINNET_SWITCHBOARD, 143);
+        }
+
+        revert("Unsupported NETWORK");
+    }
+
+    function equal(string memory a, string memory b)
+        internal
+        pure
+        returns (bool)
+    {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
     }
 }

--- a/evm/randomness/pancake-stacker/package-lock.json
+++ b/evm/randomness/pancake-stacker/package-lock.json
@@ -9,9 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@switchboard-xyz/common": "^5.5.1",
+        "@switchboard-xyz/common": "^5.7.0",
         "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-        "ethers": "^6.15.0"
+        "ethers": "^6.15.0",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -233,9 +234,9 @@
       }
     },
     "node_modules/@switchboard-xyz/common": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.5.1.tgz",
-      "integrity": "sha512-0oPooEE/E6sbLfLvW/xiPM0fqnzCh6sARWBz8lW9ABJ1IRpLqd0qmFRfFZlYkyLtaQUlb5mKfe5DrPuoyUWvoA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.7.0.tgz",
+      "integrity": "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg==",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.2",
@@ -1228,6 +1229,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/evm/randomness/pancake-stacker/package-lock.json
+++ b/evm/randomness/pancake-stacker/package-lock.json
@@ -1,17 +1,24 @@
 {
-  "name": "randomness",
+  "name": "pancake-stacker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "randomness",
+      "name": "pancake-stacker",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@switchboard-xyz/common": "^5.5.1",
-        "@switchboard-xyz/on-demand-solidity": "^1.1.0"
+        "@switchboard-xyz/on-demand-solidity": "^1.1.0",
+        "ethers": "^6.15.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
@@ -283,6 +290,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
@@ -579,6 +592,100 @@
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/eventemitter3": {

--- a/evm/randomness/pancake-stacker/package.json
+++ b/evm/randomness/pancake-stacker/package.json
@@ -15,8 +15,9 @@
   "author": "Switchboard Labs",
   "license": "MIT",
   "dependencies": {
-    "@switchboard-xyz/common": "^5.5.1",
+    "@switchboard-xyz/common": "^5.7.0",
     "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-    "ethers": "^6.15.0"
+    "ethers": "^6.15.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/evm/randomness/pancake-stacker/package.json
+++ b/evm/randomness/pancake-stacker/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "forge build",
+    "deploy": "bun run scripts/deploy.ts",
+    "deploy:monad-testnet": "NETWORK=monad-testnet bun run scripts/deploy.ts",
+    "deploy:monad-mainnet": "NETWORK=monad-mainnet bun run scripts/deploy.ts",
     "start": "bun run server.ts",
     "flip": "bun run scripts/stackPancake.ts",
     "test": "forge test"
@@ -14,7 +17,6 @@
   "dependencies": {
     "@switchboard-xyz/common": "^5.5.1",
     "@switchboard-xyz/on-demand-solidity": "^1.1.0",
-    "ethers": "^6.16.0",
-    "yaml": "^2.8.2"
+    "ethers": "^6.15.0"
   }
 }

--- a/evm/randomness/pancake-stacker/scripts/deploy.ts
+++ b/evm/randomness/pancake-stacker/scripts/deploy.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bun
+
+import { MONAD_NETWORKS, runForgeDeploy } from "../../../network";
+
+runForgeDeploy({
+  script: "deploy/PancakeStacker.s.sol:PancakeStackerScript",
+  label: "PancakeStacker",
+  allowedNetworks: MONAD_NETWORKS,
+}).catch((error) => {
+  console.error("\n❌ Error:", error.message || error);
+  process.exit(1);
+});

--- a/evm/randomness/pancake-stacker/scripts/stackPancake.ts
+++ b/evm/randomness/pancake-stacker/scripts/stackPancake.ts
@@ -1,9 +1,11 @@
 import { ethers } from "ethers";
 import { CrossbarClient } from "@switchboard-xyz/common";
-import { sleep } from "./utils";
-
-const DEFAULT_RPC_URL = "https://testnet-rpc.monad.xyz";
-const SETTLEMENT_BUFFER_SECONDS = 10;
+import {
+    MONAD_NETWORKS,
+    getValidatedNetwork,
+    requireDeployedContract,
+    requirePrivateKey,
+} from "../../../network";
 
 // defines interface for the pancake flipper contract we interact with
 const PANCAKE_STACKER_ABI = [
@@ -20,62 +22,50 @@ const PANCAKE_STACKER_ABI = [
 async function main() {
 
     // load your private key for your wallet
-    const privateKey = process.env.PRIVATE_KEY;
-    if (!privateKey) {
-        throw new Error("PRIVATE_KEY is not set");
-    }
+    const privateKey = requirePrivateKey();
+    const config = await getValidatedNetwork({
+        allowedNetworks: MONAD_NETWORKS,
+    });
+    const provider = new ethers.JsonRpcProvider(config.rpcUrl);
 
     // load on-chain contract address
-    const contractAddress = process.env.PANCAKE_STACKER_CONTRACT_ADDRESS;
-    if (!contractAddress) {
-        throw new Error("PANCAKE_STACKER_CONTRACT_ADDRESS is not set");
-    }
+    const contractAddress = await requireDeployedContract(
+        config,
+        "PANCAKE_STACKER_CONTRACT_ADDRESS",
+        "PancakeStacker"
+    );
 
     // initialize RPC, wallet, crossbar server
-    const rpcUrl = process.env.RPC_URL || DEFAULT_RPC_URL;
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
     const wallet = new ethers.Wallet(privateKey, provider);
     const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
+
+    console.log(`Network: ${config.name} (${config.key})`);
+    console.log(`Chain ID: ${config.chainId}`);
+    console.log(`RPC URL: ${config.rpcUrl}`);
+    console.log(`Switchboard: ${config.switchboard}`);
+    console.log(`PancakeStacker: ${contractAddress}`);
+    console.log(`Wallet: ${wallet.address}`);
 
     // initialize contract instance to call
     const contract = new ethers.Contract(contractAddress, PANCAKE_STACKER_ABI, wallet);
 
     // call contract to get current stats before flip
-    const [currentStack, hasPendingFlip] = await contract.getPlayerStats(wallet.address);
+    const [currentStack] = await contract.getPlayerStats(wallet.address);
     console.log(`\nCurrent stack: ${currentStack} pancakes`);
 
+    // call contract to flip a pancake
+    console.log("\nFlipping pancake...");
+    const tx = await contract.flipPancake();
+    await tx.wait();
+    console.log("Flip requested:", tx.hash);
+
     // get data of the randomness you requested
-    let flipData;
-
-    if (hasPendingFlip) {
-        console.log("\nFound pending flip, resuming settlement...");
-        flipData = await contract.getFlipData(wallet.address);
-    } else {
-        console.log("\nFlipping pancake...");
-        const tx = await contract.flipPancake();
-        await tx.wait();
-        console.log("Flip requested:", tx.hash);
-        flipData = await contract.getFlipData(wallet.address);
-    }
-
-    const settlementTime =
-        Number(flipData.rollTimestamp) + Number(flipData.minSettlementDelay);
-    const now = Math.floor(Date.now() / 1000);
-    const waitSeconds = Math.max(0, settlementTime - now + SETTLEMENT_BUFFER_SECONDS);
-
-    if (waitSeconds > 0) {
-        console.log(`Waiting ${waitSeconds}s for randomness settlement window...`);
-        await sleep(waitSeconds * 1000);
-    }
-
-    // get chain ID dynamically from the provider
-    const network = await provider.getNetwork();
-    const chainId = Number(network.chainId);
+    const flipData = await contract.getFlipData(wallet.address);
 
     // ask crossbar to talk to oracle and retrieve randomness
     console.log("Resolving randomness...");
     const { encoded } = await crossbar.resolveEVMRandomness({
-        chainId,
+        chainId: config.chainId,
         randomnessId: flipData.randomnessId,
         timestamp: Number(flipData.rollTimestamp),
         minStalenessSeconds: Number(flipData.minSettlementDelay),
@@ -120,4 +110,7 @@ async function main() {
     console.log(`Your stack: ${finalStack} pancakes`);
 }
 
-main();
+main().catch((error) => {
+    console.error("Error:", error.message || error);
+    process.exit(1);
+});

--- a/evm/randomness/randomness.ts
+++ b/evm/randomness/randomness.ts
@@ -14,54 +14,14 @@
  * - DeFi: Random liquidation selection, lottery mechanisms
  *
  * Run with:
- *   cd evm/randomness && bun install && PRIVATE_KEY=0x... bun run example
- *   cd evm/randomness && bun install && PRIVATE_KEY=0x... NETWORK=monad-mainnet bun run example
- *   cd evm/randomness && bun install && PRIVATE_KEY=0x... NETWORK=hyperliquid-mainnet bun run example
+ *   PRIVATE_KEY=0x... bun randomness/randomness.ts
+ *   PRIVATE_KEY=0x... NETWORK=monad-mainnet bun randomness/randomness.ts
+ *   PRIVATE_KEY=0x... NETWORK=hyperliquid-mainnet bun randomness/randomness.ts
  */
 
 import { ethers } from 'ethers';
 import { CrossbarClient } from '@switchboard-xyz/common';
-import { sleep } from './utils';
-
-// =============================================================================
-// Configuration
-// =============================================================================
-
-interface NetworkConfig {
-  name: string;
-  chainId: number;
-  rpcUrl: string;
-  switchboard: string;
-  blockExplorer: string;
-  symbol: string;
-}
-
-const NETWORKS: Record<string, NetworkConfig> = {
-  'monad-testnet': {
-    name: 'Monad Testnet',
-    chainId: 10143,
-    rpcUrl: 'https://testnet-rpc.monad.xyz',
-    switchboard: '0x6724818814927e057a693f4e3A172b6cC1eA690C',
-    blockExplorer: 'https://testnet.monadexplorer.com',
-    symbol: 'MON',
-  },
-  'monad-mainnet': {
-    name: 'Monad Mainnet',
-    chainId: 143,
-    rpcUrl: process.env.MONAD_RPC_URL || 'https://rpc.monad.xyz',
-    switchboard: '0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67',
-    blockExplorer: 'https://monadexplorer.com',
-    symbol: 'MON',
-  },
-  'hyperliquid-mainnet': {
-    name: 'Hyperliquid Mainnet',
-    chainId: 999,
-    rpcUrl: 'https://rpc.hyperliquid.xyz/evm',
-    switchboard: '0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347',
-    blockExplorer: 'https://explorer.hyperliquid.xyz',
-    symbol: 'ETH',
-  },
-};
+import { getValidatedNetwork, requirePrivateKey, sleep } from '../network';
 
 // Switchboard ABI for randomness functions
 const SWITCHBOARD_ABI = [
@@ -100,43 +60,35 @@ async function main() {
   console.log('═'.repeat(60));
 
   // Get configuration
-  const privateKey = process.env.PRIVATE_KEY;
-  if (!privateKey) {
-    throw new Error('PRIVATE_KEY environment variable is required');
-  }
-
-  const networkName = process.env.NETWORK || 'monad-testnet';
-  const network = NETWORKS[networkName];
-  if (!network) {
-    const available = Object.keys(NETWORKS).join(', ');
-    throw new Error(`Unknown network: ${networkName}. Available: ${available}`);
-  }
+  const privateKey = requirePrivateKey();
+  const network = await getValidatedNetwork();
+  const provider = new ethers.JsonRpcProvider(network.rpcUrl);
 
   const crossbarUrl = process.env.CROSSBAR_URL || 'https://crossbar.switchboard.xyz';
 
   // Setup provider and wallet
-  const provider = new ethers.JsonRpcProvider(network.rpcUrl);
   const wallet = new ethers.Wallet(privateKey, provider);
   const switchboard = new ethers.Contract(network.switchboard, SWITCHBOARD_ABI, wallet);
 
   console.log(`\n📋 Configuration:`);
-  console.log(`   Network:      ${network.name} (${networkName})`);
+  console.log(`   Network:      ${network.name} (${network.key})`);
   console.log(`   Chain ID:     ${network.chainId}`);
   console.log(`   Switchboard:  ${network.switchboard}`);
   console.log(`   Wallet:       ${wallet.address}`);
+  console.log(`   RPC URL:      ${network.rpcUrl}`);
   console.log(`   Crossbar:     ${crossbarUrl}`);
 
   // Check balance
   const balance = await provider.getBalance(wallet.address);
-  console.log(`   Balance:      ${ethers.formatEther(balance)} ${network.symbol}`);
+  console.log(`   Balance:      ${ethers.formatEther(balance)} ${network.nativeSymbol}`);
 
   if (balance === 0n) {
-    throw new Error(`Wallet has no balance. Get ${network.symbol} first.`);
+    throw new Error(`Wallet has no balance. Get ${network.nativeSymbol} first.`);
   }
 
   // Get update fee
   const updateFee = await switchboard.updateFee();
-  console.log(`   Update Fee:   ${ethers.formatEther(updateFee)} ${network.symbol}`);
+  console.log(`   Update Fee:   ${ethers.formatEther(updateFee)} ${network.nativeSymbol}`);
 
   // =========================================================================
   // STEP 1: Create Randomness Request
@@ -158,7 +110,7 @@ async function main() {
 
   const createTx = await switchboard.createRandomness(randomnessId, minSettlementDelay);
   console.log(`   TX Hash:  ${createTx.hash}`);
-  console.log(`   Explorer: ${network.blockExplorer}/tx/${createTx.hash}`);
+  console.log(`   Explorer: ${network.explorer}/tx/${createTx.hash}`);
 
   const createReceipt = await createTx.wait();
   console.log(`   ✅ Confirmed in block ${createReceipt.blockNumber}`);
@@ -237,7 +189,7 @@ async function main() {
 
   const settleTx = await switchboard.settleRandomness(encodedRandomness, { value: updateFee });
   console.log(`   TX Hash:  ${settleTx.hash}`);
-  console.log(`   Explorer: ${network.blockExplorer}/tx/${settleTx.hash}`);
+  console.log(`   Explorer: ${network.explorer}/tx/${settleTx.hash}`);
 
   const settleReceipt = await settleTx.wait();
   console.log(`   ✅ Settled in block ${settleReceipt.blockNumber}`);
@@ -291,8 +243,8 @@ Summary:
   • Random Value:  ${finalData.value}
 
 Transactions:
-  • Create: ${network.blockExplorer}/tx/${createTx.hash}
-  • Settle: ${network.blockExplorer}/tx/${settleTx.hash}
+  • Create: ${network.explorer}/tx/${createTx.hash}
+  • Settle: ${network.explorer}/tx/${settleTx.hash}
 
 Integration Tips:
   • Use the raw 256-bit value (finalData.value) for maximum entropy

--- a/solana/feeds/advanced/package.json
+++ b/solana/feeds/advanced/package.json
@@ -13,8 +13,9 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.1",
     "@solana/web3.js": "^1.98.0",
-    "@switchboard-xyz/common": "^5.3.1",
-    "@switchboard-xyz/on-demand": "^3.7.3",
+    "@switchboard-xyz/common": "^5.7.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
+    "yaml": "^2.8.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/solana/feeds/basic/package-lock.json
+++ b/solana/feeds/basic/package-lock.json
@@ -11,8 +11,9 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.31.1",
         "@solana/web3.js": "^1.98.0",
-        "@switchboard-xyz/common": "^5.3.1",
-        "@switchboard-xyz/on-demand": "^3.7.3",
+        "@switchboard-xyz/common": "^5.7.0",
+        "@switchboard-xyz/on-demand": "^3.9.0",
+        "yaml": "^2.8.3",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -687,9 +688,9 @@
       }
     },
     "node_modules/@switchboard-xyz/common": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.6.1.tgz",
-      "integrity": "sha512-2Sz3iAusCnpEp+lJLOcwstRxGQCkbCdLDNgAYl/gTqApCA+drdQni8WoeKdahAXtcxhr72pd9PhFi/4N25im+w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.7.0.tgz",
+      "integrity": "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg==",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.2",
@@ -707,34 +708,14 @@
       }
     },
     "node_modules/@switchboard-xyz/common-legacy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common-legacy/-/common-legacy-1.0.2.tgz",
-      "integrity": "sha512-2DGJiqIvw+ekmujcntIwO1UNcBZr1pbX7XTWcOUs2JChIqh3ceSV8jyLeyHGAi+/0eGmgF0pluxizstyf9bbzA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common-legacy/-/common-legacy-1.1.0.tgz",
+      "integrity": "sha512-8MWCkOK0ystMWY5Txlh1o+8ZJ4ksUrifWWpNJoyds7qtmTaY2nSK8gKG7AORTtktTOS9K9tdDR4RSYoLtZAJOA==",
       "license": "MIT",
       "dependencies": {
-        "@switchboard-xyz/common": "5.5.2",
+        "@switchboard-xyz/common": "5.7.0",
         "axios": "^1.9.0",
         "bs58": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@switchboard-xyz/common-legacy/node_modules/@switchboard-xyz/common": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.5.2.tgz",
-      "integrity": "sha512-/94ZkCaB1fnrjd7KW2YA702lSi/nJMrELNu0eyxOq6LU0OwX18LDo6muKyVCuKEHgGM64I0HJeOT1MtUgeVMBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/web3.js": "^1.98.2",
-        "axios": "^1.9.0",
-        "big.js": "^6.2.2",
-        "bn.js": "^5.2.1",
-        "bs58": "^6.0.0",
-        "buffer": "^6.0.3",
-        "decimal.js": "^10.4.3",
-        "js-sha256": "^0.11.0",
-        "protobufjs": "^7.4.0"
       },
       "engines": {
         "node": ">=20"
@@ -771,17 +752,17 @@
       }
     },
     "node_modules/@switchboard-xyz/on-demand": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/on-demand/-/on-demand-3.8.2.tgz",
-      "integrity": "sha512-j7I9m6g4UfMx9Hewo2b58+Rt2DqS1ii8+ztNXsF/HV5Oms3ImoIEdffvP8GPJGbORd7IAlRtjXYjaAoR2kay7g==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/on-demand/-/on-demand-3.9.0.tgz",
+      "integrity": "sha512-6rRGCiPoSaWgBL/ixnOKf/O42BXQdZFpQz81bAvdwCCvjmOTruZ5Ie+iJadDe3339vvPGRrJd4UTuHoU/scJ1Q==",
       "license": "ISC",
       "dependencies": {
         "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1",
         "@isaacs/ttlcache": "^1.4.1",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
-        "@switchboard-xyz/common": "^5.6.1",
-        "@switchboard-xyz/common-legacy": "^1.0.2",
+        "@switchboard-xyz/common": "^5.7.0",
+        "@switchboard-xyz/common-legacy": "^1.1.0",
         "axios": "^1.9",
         "bs58": "^6.0.0",
         "buffer": "^6.0.3",
@@ -2087,6 +2068,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/solana/feeds/basic/package.json
+++ b/solana/feeds/basic/package.json
@@ -14,8 +14,9 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.1",
     "@solana/web3.js": "^1.98.0",
-    "@switchboard-xyz/common": "^5.3.1",
-    "@switchboard-xyz/on-demand": "^3.7.3",
+    "@switchboard-xyz/common": "^5.7.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
+    "yaml": "^2.8.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/solana/prediction-market/package.json
+++ b/solana/prediction-market/package.json
@@ -4,8 +4,8 @@
   "description": "Switchboard integration for prediction market feeds (Kalshi)",
   "type": "module",
   "scripts": {
-    "start": "ts-node scripts/testKalshiFeedVerification.ts",
-    "test": "ts-node scripts/testKalshiFeedVerification.ts",
+    "start": "tsx scripts/testKalshiFeedVerification.ts",
+    "test": "npm run start -- --help",
     "build": "cargo build-sbf"
   },
   "author": "Switchboard Labs",
@@ -13,14 +13,16 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.1",
     "@solana/web3.js": "^1.98.0",
-    "@switchboard-xyz/common": "^5.3.1",
-    "@switchboard-xyz/on-demand": "^3.7.3",
+    "@switchboard-xyz/common": "^5.7.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
+    "yaml": "^2.8.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",
     "@types/yargs": "^17.0.33",
     "ts-node": "^10.9.2",
+    "tsx": "^4.19.1",
     "typescript": "^4.9.5"
   }
 }

--- a/solana/prediction-market/scripts/testKalshiFeedVerification.ts
+++ b/solana/prediction-market/scripts/testKalshiFeedVerification.ts
@@ -25,14 +25,14 @@
  *
  * Usage:
  * ------
- *   bun run scripts/prediction-market-examples/testKalshiFeedVerification.ts \
+ *   npm run start -- \
  *     --api-key-id YOUR_KALSHI_API_KEY_ID \
  *     --private-key-path /path/to/kalshi/private-key.pem \
  *     --order-id KALSHI_ORDER_ID
  *
  * Example:
  * --------
- *   bun run scripts/prediction-market-examples/testKalshiFeedVerification.ts \
+ *   npm run start -- \
  *     --api-key-id abc123 \
  *     --private-key-path ~/.kalshi/key.pem \
  *     --order-id 12345678-1234-1234-1234-123456789012
@@ -41,13 +41,17 @@
 import { CrossbarClient } from "@switchboard-xyz/common";
 import * as sb from "@switchboard-xyz/on-demand";
 import { Program, AnchorProvider } from "@coral-xyz/anchor";
-import { PublicKey } from "@solana/web3.js";
+import {
+  PublicKey,
+  SYSVAR_INSTRUCTIONS_PUBKEY,
+  SYSVAR_SLOT_HASHES_PUBKEY,
+} from "@solana/web3.js";
 import * as fs from "fs";
 import * as crypto from "crypto";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import * as pathModule from "path";
-import { TX_CONFIG, myAnchorProgram, PREDICTION_MARKET_PROGRAM_PATH } from "../utils";
+import { myAnchorProgram, PREDICTION_MARKET_PROGRAM_PATH } from "./utils";
 
 interface Arguments {
   apiKeyId: string;
@@ -145,7 +149,6 @@ function createSignature(
       await sb.AnchorUtils.loadEnv();
     const queue = await sb.Queue.loadDefault(anchorProgram!);
     const crossbar = new CrossbarClient(argv.crossbarUrl);
-    const gateway = await queue.fetchGatewayFromCrossbar(crossbar);
 
     console.log("🔧 Solana Configuration:");
     console.log(`  Wallet: ${keypair.publicKey.toBase58()}`);
@@ -192,7 +195,7 @@ function createSignature(
     });
 
     console.log("  ✅ Simulation Result:");
-    console.log(`    Response: ${simulation.results[0]}...\n`);
+    console.log(`    Response: ${simulation.results?.[0]}...\n`);
 
     let quoteIx;
     let lastError;
@@ -210,7 +213,6 @@ function createSignature(
               KALSHI_API_KEY_ID: argv.apiKeyId,
             },
             instructionIdx: 0,
-            payer: keypair.publicKey,
           }
         );
         console.log(`  ✅ Successfully fetched quote instruction\n`);
@@ -237,8 +239,8 @@ function createSignature(
       .verifyKalshiFeed(argv.orderId)
     .accounts({
       queue: queue.pubkey,
-      slothashSysvar: sb.SYSVAR_SLOTHASHES_PUBKEY,
-      instructionSysvar: sb.SYSVAR_INSTRUCTIONS_PUBKEY,
+      slothashSysvar: SYSVAR_SLOT_HASHES_PUBKEY,
+      instructionSysvar: SYSVAR_INSTRUCTIONS_PUBKEY,
     })
     .instruction();
 

--- a/solana/randomness/coin-flip/package.json
+++ b/solana/randomness/coin-flip/package.json
@@ -23,10 +23,11 @@
     "@coral-xyz/anchor": "^0.31.1",
     "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.98.2",
-    "@switchboard-xyz/common": "^5.2.2",
-    "@switchboard-xyz/on-demand": "^3.2.0",
+    "@switchboard-xyz/common": "^5.7.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
     "readline-sync": "^1.4.10",
     "tsx": "^4.19.1",
+    "yaml": "^2.8.3",
     "yargs": "^17.7.2"
   }
 }

--- a/solana/surge/package-lock.json
+++ b/solana/surge/package-lock.json
@@ -11,8 +11,9 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.31.1",
         "@solana/web3.js": "^1.98.0",
-        "@switchboard-xyz/common": "^5.3.1",
-        "@switchboard-xyz/on-demand": "^3.7.3",
+        "@switchboard-xyz/common": "^5.7.0",
+        "@switchboard-xyz/on-demand": "^3.9.0",
+        "yaml": "^2.8.3",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -687,9 +688,9 @@
       }
     },
     "node_modules/@switchboard-xyz/common": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.6.1.tgz",
-      "integrity": "sha512-2Sz3iAusCnpEp+lJLOcwstRxGQCkbCdLDNgAYl/gTqApCA+drdQni8WoeKdahAXtcxhr72pd9PhFi/4N25im+w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.7.0.tgz",
+      "integrity": "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg==",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.2",
@@ -707,34 +708,14 @@
       }
     },
     "node_modules/@switchboard-xyz/common-legacy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common-legacy/-/common-legacy-1.0.2.tgz",
-      "integrity": "sha512-2DGJiqIvw+ekmujcntIwO1UNcBZr1pbX7XTWcOUs2JChIqh3ceSV8jyLeyHGAi+/0eGmgF0pluxizstyf9bbzA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common-legacy/-/common-legacy-1.1.0.tgz",
+      "integrity": "sha512-8MWCkOK0ystMWY5Txlh1o+8ZJ4ksUrifWWpNJoyds7qtmTaY2nSK8gKG7AORTtktTOS9K9tdDR4RSYoLtZAJOA==",
       "license": "MIT",
       "dependencies": {
-        "@switchboard-xyz/common": "5.5.2",
+        "@switchboard-xyz/common": "5.7.0",
         "axios": "^1.9.0",
         "bs58": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@switchboard-xyz/common-legacy/node_modules/@switchboard-xyz/common": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.5.2.tgz",
-      "integrity": "sha512-/94ZkCaB1fnrjd7KW2YA702lSi/nJMrELNu0eyxOq6LU0OwX18LDo6muKyVCuKEHgGM64I0HJeOT1MtUgeVMBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/web3.js": "^1.98.2",
-        "axios": "^1.9.0",
-        "big.js": "^6.2.2",
-        "bn.js": "^5.2.1",
-        "bs58": "^6.0.0",
-        "buffer": "^6.0.3",
-        "decimal.js": "^10.4.3",
-        "js-sha256": "^0.11.0",
-        "protobufjs": "^7.4.0"
       },
       "engines": {
         "node": ">=20"
@@ -771,17 +752,17 @@
       }
     },
     "node_modules/@switchboard-xyz/on-demand": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/on-demand/-/on-demand-3.8.2.tgz",
-      "integrity": "sha512-j7I9m6g4UfMx9Hewo2b58+Rt2DqS1ii8+ztNXsF/HV5Oms3ImoIEdffvP8GPJGbORd7IAlRtjXYjaAoR2kay7g==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/on-demand/-/on-demand-3.9.0.tgz",
+      "integrity": "sha512-6rRGCiPoSaWgBL/ixnOKf/O42BXQdZFpQz81bAvdwCCvjmOTruZ5Ie+iJadDe3339vvPGRrJd4UTuHoU/scJ1Q==",
       "license": "ISC",
       "dependencies": {
         "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1",
         "@isaacs/ttlcache": "^1.4.1",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
-        "@switchboard-xyz/common": "^5.6.1",
-        "@switchboard-xyz/common-legacy": "^1.0.2",
+        "@switchboard-xyz/common": "^5.7.0",
+        "@switchboard-xyz/common-legacy": "^1.1.0",
         "axios": "^1.9",
         "bs58": "^6.0.0",
         "buffer": "^6.0.3",
@@ -2087,6 +2068,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/solana/surge/package.json
+++ b/solana/surge/package.json
@@ -11,8 +11,9 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.1",
     "@solana/web3.js": "^1.98.0",
-    "@switchboard-xyz/common": "^5.3.1",
-    "@switchboard-xyz/on-demand": "^3.7.3",
+    "@switchboard-xyz/common": "^5.7.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
+    "yaml": "^2.8.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/solana/x402/package.json
+++ b/solana/x402/package.json
@@ -13,10 +13,11 @@
     "@solana/kit": "^6.0.1",
     "@solana/spl-token": "^0.4.13",
     "@solana/web3.js": "^1.98.0",
-    "@switchboard-xyz/common": "^5.3.1",
-    "@switchboard-xyz/on-demand": "^3.7.3",
+    "@switchboard-xyz/common": "^5.7.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
     "@x402/fetch": "^2.2.0",
     "@x402/svm": "^2.2.0",
+    "yaml": "^2.8.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/sui/feeds/basic/package.json
+++ b/sui/feeds/basic/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@mysten/sui": "^1.38.0",
-    "@switchboard-xyz/on-demand": "^1.0.0",
+    "@switchboard-xyz/on-demand": "^3.9.0",
     "@switchboard-xyz/sui-sdk": "^0.1.14",
     "yargs": "^17.7.2"
   },

--- a/sui/surge/basic/package-lock.json
+++ b/sui/surge/basic/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@mysten/sui": "^1.38.0",
         "@solana/web3.js": "^1.98.4",
-        "@switchboard-xyz/on-demand": "^3.7.3",
+        "@switchboard-xyz/on-demand": "^3.9.0",
         "@switchboard-xyz/sui-sdk": "^0.1.14",
         "yargs": "^17.7.2"
       },
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@switchboard-xyz/common": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.6.1.tgz",
-      "integrity": "sha512-2Sz3iAusCnpEp+lJLOcwstRxGQCkbCdLDNgAYl/gTqApCA+drdQni8WoeKdahAXtcxhr72pd9PhFi/4N25im+w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.7.0.tgz",
+      "integrity": "sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg==",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.2",
@@ -1290,12 +1290,12 @@
       }
     },
     "node_modules/@switchboard-xyz/common-legacy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common-legacy/-/common-legacy-1.0.2.tgz",
-      "integrity": "sha512-2DGJiqIvw+ekmujcntIwO1UNcBZr1pbX7XTWcOUs2JChIqh3ceSV8jyLeyHGAi+/0eGmgF0pluxizstyf9bbzA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common-legacy/-/common-legacy-1.1.0.tgz",
+      "integrity": "sha512-8MWCkOK0ystMWY5Txlh1o+8ZJ4ksUrifWWpNJoyds7qtmTaY2nSK8gKG7AORTtktTOS9K9tdDR4RSYoLtZAJOA==",
       "license": "MIT",
       "dependencies": {
-        "@switchboard-xyz/common": "5.5.2",
+        "@switchboard-xyz/common": "5.7.0",
         "axios": "^1.9.0",
         "bs58": "^6.0.0"
       },
@@ -1303,38 +1303,18 @@
         "node": ">=20"
       }
     },
-    "node_modules/@switchboard-xyz/common-legacy/node_modules/@switchboard-xyz/common": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/common/-/common-5.5.2.tgz",
-      "integrity": "sha512-/94ZkCaB1fnrjd7KW2YA702lSi/nJMrELNu0eyxOq6LU0OwX18LDo6muKyVCuKEHgGM64I0HJeOT1MtUgeVMBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/web3.js": "^1.98.2",
-        "axios": "^1.9.0",
-        "big.js": "^6.2.2",
-        "bn.js": "^5.2.1",
-        "bs58": "^6.0.0",
-        "buffer": "^6.0.3",
-        "decimal.js": "^10.4.3",
-        "js-sha256": "^0.11.0",
-        "protobufjs": "^7.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@switchboard-xyz/on-demand": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@switchboard-xyz/on-demand/-/on-demand-3.8.2.tgz",
-      "integrity": "sha512-j7I9m6g4UfMx9Hewo2b58+Rt2DqS1ii8+ztNXsF/HV5Oms3ImoIEdffvP8GPJGbORd7IAlRtjXYjaAoR2kay7g==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@switchboard-xyz/on-demand/-/on-demand-3.9.0.tgz",
+      "integrity": "sha512-6rRGCiPoSaWgBL/ixnOKf/O42BXQdZFpQz81bAvdwCCvjmOTruZ5Ie+iJadDe3339vvPGRrJd4UTuHoU/scJ1Q==",
       "license": "ISC",
       "dependencies": {
         "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1",
         "@isaacs/ttlcache": "^1.4.1",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
-        "@switchboard-xyz/common": "^5.6.1",
-        "@switchboard-xyz/common-legacy": "^1.0.2",
+        "@switchboard-xyz/common": "^5.7.0",
+        "@switchboard-xyz/common-legacy": "^1.1.0",
         "axios": "^1.9",
         "bs58": "^6.0.0",
         "buffer": "^6.0.3",

--- a/sui/surge/basic/package.json
+++ b/sui/surge/basic/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@mysten/sui": "^1.38.0",
     "@solana/web3.js": "^1.98.4",
-    "@switchboard-xyz/on-demand": "^3.7.3",
+    "@switchboard-xyz/on-demand": "^3.9.0",
     "@switchboard-xyz/sui-sdk": "^0.1.14",
     "yargs": "^17.7.2"
   },


### PR DESCRIPTION
## Summary
- add a shared EVM `NETWORK` switch so the Monad examples can flip between testnet and mainnet with one env var
- standardize EVM deploy/runtime/docs around the shared network resolver and guardrails
- upgrade the current example manifests to `@switchboard-xyz/on-demand@^3.9.0` and `@switchboard-xyz/common@^5.7.0`
- add explicit `yaml` deps where `@switchboard-xyz/common@5.7.0` needs them at runtime
- patch the Solana prediction-market and common twitter examples so they still run cleanly on the upgraded pins

## Validation
- `bunx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 job-testing/runJob.ts streaming/crossbarStream.ts` in `common`
- `npx tsc --noEmit -p tsconfig.json` in `common/twitter-follower-count`
- `npm run update` in `solana/feeds/basic`
- `npm run update` in `solana/feeds/advanced`
- `npm test` in `solana/prediction-market`
- `npm run start -- heads` in `solana/randomness/coin-flip`
- `npm run start -- --help` in `solana/surge`
- `npm run build:testnet` in `sui/feeds/basic`
- `npm run quotes` in `sui/feeds/basic`
- `npm run stream -- --help` in `sui/surge/basic`
- `bun scripts/surgeToEvmConversion.ts` in `evm/price-feeds`
- `bun scripts/run.ts` in `evm/price-feeds` to confirm the expected `PRIVATE_KEY` guardrail
- `bun randomness.ts` in `evm/randomness` to confirm the expected `PRIVATE_KEY` guardrail
- `bun run scripts/flipCoin.ts` in `evm/randomness/coin-flip` to confirm the expected `PRIVATE_KEY` guardrail
- `bun run scripts/stackPancake.ts` in `evm/randomness/pancake-stacker` to confirm the expected `PRIVATE_KEY` guardrail
- `forge build` in `evm/price-feeds`
- `forge build` in `evm/randomness/coin-flip`
- `forge build` in `evm/randomness/pancake-stacker`

## Notes
- I opened this from a fresh branch instead of reusing `jack/improve-randomness` because that branch had already been used for earlier squash-merged PRs and would have produced a noisy diff against `main`.
