### PR TITLE
Switch EVM price feed examples to v2 Crossbar updates

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -95,30 +95,53 @@ evm/
 
 Real-time oracle price data for DeFi applications.
 
+For Feed Builder and custom feeds on Monad, use the v2 feed-hash flow. The legacy `fetchEVMResults` path is kept only under [legacy examples](./legacy/).
+
 ### Integration Example
 
 ```typescript
 import { ethers } from 'ethers';
 import { CrossbarClient } from '@switchboard-xyz/common';
 
+const privateKey = process.env.PRIVATE_KEY!;
+const contractAddress = process.env.CONTRACT_ADDRESS!;
+const switchboardAddress = process.env.SWITCHBOARD_ADDRESS!;
+const rpcUrl = process.env.RPC_URL ?? 'https://testnet-rpc.monad.xyz';
+
 const SWITCHBOARD_ABI = [
   'function getFee(bytes[] calldata updates) external view returns (uint256)',
+];
+const PRICE_CONSUMER_ABI = [
+  'function updatePrices(bytes[] calldata updates, bytes32[] calldata feedIds) external payable',
+  'function getPrice(bytes32 feedId) external view returns (int128 value, uint256 timestamp, uint64 slotNumber)',
 ];
 
 const provider = new ethers.JsonRpcProvider(rpcUrl);
 const signer = new ethers.Wallet(privateKey, provider);
+const crossbarNetwork = process.env.NETWORK === 'monad-mainnet' ? 'mainnet' : 'testnet';
+const feedId = '0xa0950ee5ee117b2e2c30f154a69e17bfb489a7610c508dc5f67eb2a14616d8ea';
 
 // Fetch oracle data
 const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
-const { encoded } = await crossbar.fetchEVMResults({
-  chainId: 143,
-  aggregatorIds: [feedHash],
+await crossbar.simulateFeed(feedId, false, undefined, crossbarNetwork);
+
+const response = await crossbar.fetchV2Update([feedId], {
+  chain: 'evm',
+  network: crossbarNetwork,
+  use_timestamp: true,
 });
 
+if (!response.encoded) {
+  throw new Error('Crossbar returned no encoded update payload');
+}
+
+const updates = [response.encoded];
+
 // Submit update
+const contract = new ethers.Contract(contractAddress, PRICE_CONSUMER_ABI, signer);
 const switchboard = new ethers.Contract(switchboardAddress, SWITCHBOARD_ABI, signer);
-const fee = await switchboard.getFee(encoded);
-const tx = await contract.updatePrices(encoded, [feedHash], { value: fee });
+const fee = await switchboard.getFee(updates);
+const tx = await contract.updatePrices(updates, [feedId], { value: fee });
 await tx.wait();
 
 // Query price

--- a/evm/legacy/README.md
+++ b/evm/legacy/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the previous version of the EVM examples using the older Switchboard implementation.
 
+This is the only EVM example set that intentionally uses the legacy `aggregatorId` + `fetchEVMResults()` flow. New Monad and Feed Builder integrations in the parent directory use `fetchV2Update()` instead.
+
 ## 📁 Contents
 
 - **`src/Example.sol`** - Basic example contract using the legacy Switchboard interface
@@ -96,9 +98,8 @@ See the [main README](../README.md) for the new implementation.
 
 - [Switchboard Documentation](https://docs.switchboard.xyz)
 - [Legacy Contract Addresses](https://docs.switchboard.xyz/product-documentation/data-feeds/evm/contract-addresses)
-- [Discord Community](https://discord.gg/TJAv6ZYvPC)
+- [Discord Community](https://discord.gg/switchboardxyz)
 
 ---
 
 **Note**: This legacy implementation is maintained for reference and compatibility with existing deployments on non-Monad chains. For new projects, please use the updated implementation in the parent directory.
-

--- a/evm/price-feeds/scripts/run.ts
+++ b/evm/price-feeds/scripts/run.ts
@@ -112,49 +112,54 @@ function formatValue(value: bigint, decimals: number = 18): string {
   return `${whole}.${trimmed}`;
 }
 
+function getCrossbarNetwork(networkName: string): 'mainnet' | 'testnet' {
+  return networkName === 'monad-mainnet' ? 'mainnet' : 'testnet';
+}
+
 async function fetchFeedData(
   feedHash: string,
   networkConfig: ResolvedNetworkConfig
 ) {
   const normalizedHash = normalizeFeedHash(feedHash);
+  const crossbarNetwork = getCrossbarNetwork(networkConfig.name);
 
   console.log('📡 Fetching feed data from Switchboard Crossbar...');
   console.log(`   Feed: ${normalizedHash}`);
   console.log(`   Chain ID: ${networkConfig.chainId}`);
+  console.log(`   Crossbar network: ${crossbarNetwork}`);
 
   try {
     const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
-    const response = await crossbar.fetchEVMResults({
-      chainId: networkConfig.chainId,
-      aggregatorIds: [normalizedHash],
+    const response = await crossbar.fetchV2Update([normalizedHash], {
+      chain: 'evm',
+      network: crossbarNetwork,
+      use_timestamp: true,
     });
-    const failures = (response as { failures?: string[] }).failures;
 
-    if (!response.encoded.length) {
-      throw new Error(
-        failures?.join('; ') || 'No encoded data returned for this feed'
-      );
+    if (!response.encoded) {
+      throw new Error('No encoded data returned for this feed');
     }
 
-    const latestResult = response.results?.[0];
-    if (failures?.length) {
-      console.warn(`⚠️  Crossbar reported failures: ${failures.join('; ')}`);
+    const latestResult =
+      response.medianResponses.find(
+        medianResponse =>
+          medianResponse.feedHash.toLowerCase() === normalizedHash.toLowerCase()
+      ) ?? response.medianResponses[0];
+
+    if (!latestResult) {
+      throw new Error('No median response returned for this feed');
     }
 
     console.log('✅ Feed data retrieved:');
-    if (latestResult?.result) {
-      console.log(`   Value: ${formatValue(BigInt(latestResult.result))}`);
-    }
-    if (latestResult?.timestamp) {
-      console.log(`   Timestamp: ${new Date(latestResult.timestamp * 1000).toISOString()}`);
-    }
-    console.log(`   Encoded updates: ${response.encoded.length}`);
+    console.log(`   Value: ${formatValue(BigInt(latestResult.value))}`);
+    console.log(`   Timestamp: ${new Date(response.timestamp * 1000).toISOString()}`);
+    console.log('   Encoded updates: 1');
 
     return {
       feedHash: normalizedHash,
-      value: latestResult?.result,
-      timestamp: latestResult?.timestamp,
-      encoded: response.encoded,
+      value: latestResult.value,
+      timestamp: response.timestamp,
+      encoded: [response.encoded],
     };
   } catch (error: any) {
     throw new Error(`Failed to fetch feed data: ${error.message}`);


### PR DESCRIPTION
## Summary
- update the active EVM price-feed example docs and script to use the v2 feed-hash update flow
- keep the legacy README explicitly marked as the only `fetchEVMResults(...)` example path

## What changed
- change the main EVM README example from `fetchEVMResults(...)` to `simulateFeed(...)` + `fetchV2Update(...)`
- update `evm/price-feeds/scripts/run.ts` to request v2 EVM payloads and wrap `response.encoded` into `bytes[]` for `getFee` and `updatePrices`
- clarify in `evm/legacy/README.md` that legacy aggregator IDs are for older integrations only

## Verification
- the updated script logic was exercised in the existing workspace up to runtime validation (`PRIVATE_KEY` required)
- `forge build` in a fresh PR worktree is currently blocked by a missing `forge-std` path on `origin/main`, which appears unrelated to this change set