### PR TITLE
evm: clean up monad feeds and coin flip flow

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -44,10 +44,12 @@ Each example is a standalone Foundry project. Navigate to the specific example a
 ```bash
 # Price Feeds Example
 cd evm/price-feeds
-bun install && forge build
+bun install
+(cd ../randomness/coin-flip && ([ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow))
+forge build
 cp .env.example .env  # Edit .env with your private key
 
-# Default: Monad testnet
+# Default: Monad testnet. If CONTRACT_ADDRESS is unset, this deploys a fresh consumer automatically.
 bun run example
 
 # Flip everything to Monad mainnet with one env var
@@ -55,14 +57,19 @@ NETWORK=monad-mainnet bun run example
 
 # Randomness Examples
 cd ../randomness/coin-flip   # or pancake-stacker
-bun install && forge build
+bun install
+[ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
+forge build
 cp .env.example .env  # Edit .env with your private key
 bun run deploy
+# Save the emitted contract address back into .env before running the CLI.
+# For coin-flip, fund the contract bankroll before the first flip.
 bun run flip
 
 # Generic randomness helper
 cd ../
 bun install
+cp .env.example .env  # Edit .env with your private key
 bun run example
 ```
 
@@ -275,12 +282,15 @@ Cryptographically secure verifiable randomness for gaming, NFTs, and DeFi.
 ```bash
 # Navigate to a randomness example
 cd evm/randomness/coin-flip  # or pancake-stacker
-bun install && forge build
+bun install
+[ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
+forge build
 
 # Configure environment
 cp .env.example .env  # Edit .env with your private key and contract address
 
-# Run the example
+# Deploy, save the emitted contract address into .env, then run the example.
+# For coin-flip, fund the contract bankroll before the first flip.
 bun run flip
 ```
 

--- a/evm/price-feeds/DEPLOYMENT.md
+++ b/evm/price-feeds/DEPLOYMENT.md
@@ -41,6 +41,10 @@ Before broadcasting, the packaged deploy flow verifies:
 
 ```bash
 bun install
+(
+  cd ../randomness/coin-flip
+  [ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
+)
 forge build
 cp .env.example .env
 ```

--- a/evm/price-feeds/README.md
+++ b/evm/price-feeds/README.md
@@ -43,6 +43,10 @@ The deploy and runtime scripts enforce guardrails before broadcast:
 
 ```bash
 bun install
+(
+  cd ../randomness/coin-flip
+  [ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
+)
 forge build
 cp .env.example .env
 ```

--- a/evm/price-feeds/scripts/run.ts
+++ b/evm/price-feeds/scripts/run.ts
@@ -112,8 +112,8 @@ function formatValue(value: bigint, decimals: number = 18): string {
   return `${whole}.${trimmed}`;
 }
 
-function getCrossbarNetwork(networkName: string): 'mainnet' | 'testnet' {
-  return networkName === 'monad-mainnet' ? 'mainnet' : 'testnet';
+function getCrossbarNetwork(networkKey: string): 'mainnet' | 'testnet' {
+  return networkKey === 'monad-mainnet' ? 'mainnet' : 'testnet';
 }
 
 async function fetchFeedData(
@@ -121,7 +121,7 @@ async function fetchFeedData(
   networkConfig: ResolvedNetworkConfig
 ) {
   const normalizedHash = normalizeFeedHash(feedHash);
-  const crossbarNetwork = getCrossbarNetwork(networkConfig.name);
+  const crossbarNetwork = getCrossbarNetwork(networkConfig.key);
 
   console.log('📡 Fetching feed data from Switchboard Crossbar...');
   console.log(`   Feed: ${normalizedHash}`);

--- a/evm/randomness/.env.example
+++ b/evm/randomness/.env.example
@@ -1,0 +1,14 @@
+# Private key for signing transactions (with 0x prefix)
+PRIVATE_KEY=0xyour_private_key_here
+
+# Network to use (monad-testnet, monad-mainnet, hyperliquid-mainnet)
+NETWORK=monad-testnet
+
+# RPC URL (optional - uses the default for NETWORK if not set)
+RPC_URL=
+
+# Advanced override only. For Monad, this must match the canonical address for the selected NETWORK.
+SWITCHBOARD_ADDRESS=
+
+# Crossbar URL (optional)
+CROSSBAR_URL=

--- a/evm/randomness/coin-flip/README.md
+++ b/evm/randomness/coin-flip/README.md
@@ -7,6 +7,8 @@ This example shows the standard EVM randomness flow with a simple wagering game:
 3. Ask Crossbar for the encoded randomness reveal
 4. Call `settleFlip(encoded)` to verify and use the result on-chain
 
+The contract accepts any positive wager. The packaged CLI uses a `0.01 MON` smoke-test wager by default.
+
 ## Prerequisites
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
@@ -42,6 +44,7 @@ Guardrails:
 
 ```bash
 bun install
+[ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
 forge build
 cp .env.example .env
 ```
@@ -79,6 +82,15 @@ bun run deploy:monad-mainnet
 
 After deployment, save the emitted contract address into `COIN_FLIP_CONTRACT_ADDRESS`.
 
+Before running the CLI, fund the contract with a separate bankroll so it can pay winning flips. For the packaged `0.01 MON` smoke test, a minimal example is:
+
+```bash
+cast send $COIN_FLIP_CONTRACT_ADDRESS \
+  --rpc-url ${RPC_URL:-https://testnet-rpc.monad.xyz} \
+  --private-key $PRIVATE_KEY \
+  --value 0.01ether
+```
+
 ## Run The Coin Flip
 
 ```bash
@@ -91,7 +103,8 @@ The runtime script will:
 - verify the RPC chain ID
 - verify the Switchboard contract exists on that chain
 - verify `COIN_FLIP_CONTRACT_ADDRESS` exists on that chain
-- submit the flip
+- check the contract bankroll for the default `0.01 MON` wager
+- submit the flip with a `0.01 MON` wager
 - resolve the randomness through Crossbar
 - settle the result on-chain
 
@@ -112,3 +125,5 @@ forge script deploy/CoinFlip.s.sol:CoinFlipScript \
   --rpc-url $RPC_URL \
   --broadcast
 ```
+
+After the Forge deploy completes, save the emitted contract address into `COIN_FLIP_CONTRACT_ADDRESS`, fund the bankroll, and then run `bun run flip` with the same `.env` file.

--- a/evm/randomness/coin-flip/scripts/flipCoin.ts
+++ b/evm/randomness/coin-flip/scripts/flipCoin.ts
@@ -7,6 +7,8 @@ import {
     requirePrivateKey,
 } from "../../../network";
 
+const DEFAULT_WAGER_AMOUNT = ethers.parseEther("0.01");
+
 async function main() {
     const privateKey = requirePrivateKey();
     const config = await getValidatedNetwork({
@@ -30,6 +32,9 @@ async function main() {
     console.log(`Switchboard: ${config.switchboard}`);
     console.log(`CoinFlip: ${COIN_FLIP_CONTRACT_ADDRESS}`);
     console.log(`Wallet: ${wallet.address}`);
+    console.log(
+        `Default wager: ${ethers.formatEther(DEFAULT_WAGER_AMOUNT)} ${config.nativeSymbol}`
+    );
 
     // CoinFlip ABI
     const coinFlipAbi = [
@@ -43,9 +48,24 @@ async function main() {
 
     // CoinFlip contract
     const coinFlipContract = new ethers.Contract(COIN_FLIP_CONTRACT_ADDRESS, coinFlipAbi, wallet);
+    const contractBalance = await provider.getBalance(COIN_FLIP_CONTRACT_ADDRESS);
+
+    console.log(
+        `Contract bankroll: ${ethers.formatEther(contractBalance)} ${config.nativeSymbol}`
+    );
+
+    if (contractBalance < DEFAULT_WAGER_AMOUNT) {
+        throw new Error(
+            `CoinFlip bankroll is too low for the default ${ethers.formatEther(
+                DEFAULT_WAGER_AMOUNT
+            )} ${config.nativeSymbol} wager. Fund the contract with at least ${ethers.formatEther(
+                DEFAULT_WAGER_AMOUNT
+            )} ${config.nativeSymbol} before running bun run flip.`
+        );
+    }
 
     // Run the coin flip
-    const tx = await coinFlipContract.coinFlip({ value: ethers.parseEther("1") });
+    const tx = await coinFlipContract.coinFlip({ value: DEFAULT_WAGER_AMOUNT });
     await tx.wait();
     console.log("Coin flip transaction sent", tx);
 

--- a/evm/randomness/coin-flip/src/CoinFlip.sol
+++ b/evm/randomness/coin-flip/src/CoinFlip.sol
@@ -19,9 +19,6 @@ contract CoinFlip {
     event FlipSettled(address indexed user, bool won, uint256 payout, uint256 randomValue);
     event SettlementFailed(address indexed user);
 
-    // minimum flip amount
-    uint256 public constant MIN_FLIP_AMOUNT = 0.01 ether;
-
     // Wager data mapping
     mapping(address => Wager) public wagers;
 
@@ -36,8 +33,9 @@ contract CoinFlip {
 
     // do the flip
     function coinFlip() public payable {
-        require(msg.value == MIN_FLIP_AMOUNT, "Must send exactly 0.01 native token");
+        require(msg.value > 0, "Must send a positive wager");
         require(wagers[msg.sender].amount == 0, "Already flipped");
+        require(address(this).balance >= msg.value * 2, "Insufficient bankroll");
         bytes32 randomnessId = keccak256(abi.encodePacked(msg.sender, blockhash(block.number - 1)));
         switchboard.createRandomness(randomnessId, 1);
         wagers[msg.sender] = Wager({

--- a/evm/randomness/coin-flip/test/CoinFlip.t.sol
+++ b/evm/randomness/coin-flip/test/CoinFlip.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {CoinFlip} from "../src/CoinFlip.sol";
+import {SwitchboardTypes} from "@switchboard-xyz/on-demand-solidity/libraries/SwitchboardTypes.sol";
+
+contract MockSwitchboard {
+    mapping(bytes32 => SwitchboardTypes.Randomness) internal randomness;
+    address internal oracle = address(0xBEEF);
+    bool internal settleShouldSucceed = true;
+
+    function setSettleShouldSucceed(bool value) external {
+        settleShouldSucceed = value;
+    }
+
+    function createRandomness(
+        bytes32 randomnessId,
+        uint64 minSettlementDelay
+    ) external returns (address) {
+        randomness[randomnessId] = SwitchboardTypes.Randomness({
+            randId: randomnessId,
+            createdAt: block.timestamp,
+            authority: msg.sender,
+            rollTimestamp: block.timestamp,
+            minSettlementDelay: minSettlementDelay,
+            oracle: oracle,
+            value: 0,
+            settledAt: 0
+        });
+
+        return oracle;
+    }
+
+    function settleRandomness(bytes calldata encodedRandomness) external payable {
+        require(settleShouldSucceed, "settle failed");
+
+        (bytes32 randomnessId, uint256 value) = abi.decode(
+            encodedRandomness,
+            (bytes32, uint256)
+        );
+
+        randomness[randomnessId].value = value;
+        randomness[randomnessId].settledAt = block.timestamp;
+    }
+
+    function getRandomness(
+        bytes32 randomnessId
+    ) external view returns (SwitchboardTypes.Randomness memory) {
+        return randomness[randomnessId];
+    }
+}
+
+contract CoinFlipTest is Test {
+    CoinFlip internal coinFlip;
+    MockSwitchboard internal switchboard;
+
+    address internal player = address(0xA11CE);
+
+    function setUp() public {
+        switchboard = new MockSwitchboard();
+        coinFlip = new CoinFlip(address(switchboard));
+
+        vm.deal(player, 10 ether);
+    }
+
+    function testRevertsWhenWagerIsZero() public {
+        vm.prank(player);
+        vm.expectRevert("Must send a positive wager");
+        coinFlip.coinFlip{value: 0}();
+    }
+
+    function testAcceptsArbitraryPositiveWager() public {
+        uint256 wager = 0.123 ether;
+
+        vm.deal(address(coinFlip), wager);
+
+        vm.prank(player);
+        coinFlip.coinFlip{value: wager}();
+
+        (
+            uint256 amount,
+            address user,
+            bytes32 randomnessId,
+            uint256 flipTimestamp
+        ) = coinFlip.wagers(player);
+
+        assertEq(amount, wager);
+        assertEq(user, player);
+        assertTrue(randomnessId != bytes32(0));
+        assertTrue(flipTimestamp > 0);
+    }
+
+    function testRevertsWhenBankrollCannotCoverWin() public {
+        vm.prank(player);
+        vm.expectRevert("Insufficient bankroll");
+        coinFlip.coinFlip{value: 0.01 ether}();
+    }
+
+    function testPaysWinnerWhenContractIsFunded() public {
+        uint256 wager = 0.01 ether;
+        uint256 initialBalance = player.balance;
+
+        vm.deal(address(coinFlip), wager);
+
+        vm.prank(player);
+        coinFlip.coinFlip{value: wager}();
+
+        bytes32 randomnessId = coinFlip.getWagerRandomnessId(player);
+
+        vm.prank(player);
+        coinFlip.settleFlip(abi.encode(randomnessId, uint256(2)));
+
+        assertEq(player.balance, initialBalance + wager);
+
+        (uint256 amount, , , ) = coinFlip.wagers(player);
+        assertEq(amount, 0);
+    }
+}

--- a/evm/randomness/pancake-stacker/README.md
+++ b/evm/randomness/pancake-stacker/README.md
@@ -41,6 +41,7 @@ Guardrails:
 
 ```bash
 bun install
+[ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
 forge build
 cp .env.example .env
 ```


### PR DESCRIPTION
## Summary
- fix the Monad price-feed example docs and runtime details around bootstrap and auto-deploy
- switch the packaged Coin Flip flow to a 0.01 MON smoke-test wager while allowing any positive wager on-chain
- document and enforce bankroll funding before flip, and add Coin Flip regression tests

## Verification
- `forge test` in `evm/randomness/coin-flip`
- `forge build` in `evm/price-feeds`
- `forge build` in `evm/randomness/pancake-stacker`
- live Monad testnet price-feed update via the v2 flow succeeded earlier on the source branch
- live generic randomness helper succeeded earlier on the source branch

## Notes
- live Coin Flip deployment smoke is still blocked by the current test wallet's remaining Monad testnet balance