### PR TITLE
Clarify Sui example queue fees

### DIFF
--- a/sui/feeds/basic/README.md
+++ b/sui/feeds/basic/README.md
@@ -460,6 +460,8 @@ const result = await client.signAndExecuteTransaction({
 });
 ```
 
+> **Queue fees:** The checked-in Sui example scripts remain correct when `queue.fee == 0`. If the queue accepts SUI as a fee type, `Quote.fetchUpdateQuote(sb, tx, { ... })` still works unchanged because the SDK auto-splits the exact fee from transaction gas. If the queue requires a non-SUI fee coin, you must call `Quote.fetchUpdateQuote(sb, tx, { ..., feeCoin, feeType })` with an exact-amount coin accepted by the queue. That explicit non-SUI paid path is not wired into `scripts/run.ts` or `scripts/quotes.ts` today.
+
 ## 🐛 Troubleshooting
 
 ### "Quote Consumer ID not found"

--- a/sui/surge/basic/README.md
+++ b/sui/surge/basic/README.md
@@ -45,6 +45,8 @@ export SOLANA_KEYPAIR_PATH=/path/to/your/solana/id.json
 4. The SDK signs/authenticates with your keypair (signature-based auth).
 5. Connect and subscribe to price streams over WebSocket, then use your Sui keypair only when you submit Sui transactions.
 
+> **Queue fees:** The checked-in `scripts/stream.ts` example calls `emitSurgeQuote(switchboardClient, transaction, rawResponse)` and remains correct for queues with `fee == 0`. If the queue accepts SUI as a fee type, the Sui SDK auto-splits the exact verifier fee from transaction gas. If the queue requires a non-SUI fee coin, you must call `emitSurgeQuote(switchboardClient, transaction, rawResponse, { feeCoin, feeType })`. That explicit non-SUI paid path is not covered by this minimal example.
+
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add Sui README notes explaining quote queue fee behavior for the feeds and Surge examples
- clarify that the checked-in examples still work unchanged for zero-fee queues and SUI fee queues
- note that non-SUI paid queues require explicit `feeCoin` and `feeType`, which these minimal examples do not wire up yet

## Testing
- `git diff --check -- sui/feeds/basic/README.md sui/surge/basic/README.md`
- `rg -n "Quote\\.fetchUpdateQuote|emitSurgeQuote|feeCoin|feeType" sui`
- manual source review confirming the Sui scripts remain the zero-fee-first path
