### PR TITLE
[codex] Document example feed parameter units

### DIFF
--- a/evm/price-feeds/scripts/surgeToEvmConversion.ts
+++ b/evm/price-feeds/scripts/surgeToEvmConversion.ts
@@ -104,7 +104,7 @@ async function demonstrateSurgeToEvmConversion() {
 
     // Perform the conversion
     const evmEncoded = EVMUtils.convertSurgeUpdateToEvmFormat(surgeData, {
-      minOracleSamples: 1
+      minOracleSamples: 1 // unscaled oracle-sample quorum
     });
 
     console.log('✅ EVM Conversion Results:');

--- a/evm/price-feeds/src/switchboard/libraries/SwitchboardTypes.sol
+++ b/evm/price-feeds/src/switchboard/libraries/SwitchboardTypes.sol
@@ -24,7 +24,7 @@ library SwitchboardTypes {
      * @notice Structure containing feed information
      * @param feedId The unique identifier (checksum) of the feed
      * @param value The current value of the feed
-     * @param minOracleSamples Minimum number of oracle samples required for this feed
+     * @param minOracleSamples Minimum number of oracle samples required for this feed, unscaled
      */
     struct FeedInfo {
         bytes32 feedId;

--- a/solana/feeds/basic/scripts/createManagedFeed.ts
+++ b/solana/feeds/basic/scripts/createManagedFeed.ts
@@ -60,9 +60,9 @@ const argv = yargs(process.argv)
   const oracleFeed = OracleFeed.fromObject({
     name: `${argv.base}/${argv.quote} Price Feed`,
     jobs: jobs,
-    minOracleSamples: 1,
-    minJobResponses: 1,
-    maxJobRangePct: 1,
+    minOracleSamples: 1, // unscaled oracle/signature quorum
+    minJobResponses: 1, // unscaled job/source quorum
+    maxJobRangePct: 1_000_000_000, // 1%, scaled by 1e9
   });
 
 

--- a/solana/prediction-market/programs/prediction-market/README.md
+++ b/solana/prediction-market/programs/prediction-market/README.md
@@ -90,9 +90,9 @@ let feed = OracleFeed {
             weight: None,
         }
     ],
-    min_job_responses: Some(1),
-    min_oracle_samples: Some(1),
-    max_job_range_pct: Some(0),
+    min_job_responses: Some(1), // unscaled job/source quorum
+    min_oracle_samples: Some(1), // unscaled oracle/signature quorum
+    max_job_range_pct: Some(0), // Intentional for this single-source verification; use a positive scaled value for normal multi-source feeds.
 };
 ```
 

--- a/solana/prediction-market/programs/prediction-market/src/lib.rs
+++ b/solana/prediction-market/programs/prediction-market/src/lib.rs
@@ -99,9 +99,9 @@ fn create_kalshi_feed_id(order_id: &str) -> Result<[u8; 32]> {
                 weight: None,
             }
         ],
-        min_job_responses: Some(1),
-        min_oracle_samples: Some(1),
-        max_job_range_pct: Some(0),
+        min_job_responses: Some(1), // unscaled job/source quorum
+        min_oracle_samples: Some(1), // unscaled oracle/signature quorum
+        max_job_range_pct: Some(0), // Intentional for this single-source verification; use a positive scaled value for normal multi-source feeds.
     };
 
     // Encode as protobuf length-delimited bytes using prost::Message trait

--- a/solana/prediction-market/scripts/testKalshiFeedVerification.ts
+++ b/solana/prediction-market/scripts/testKalshiFeedVerification.ts
@@ -159,9 +159,9 @@ function createSignature(
 
     const oracleFeed = {
       name: "Kalshi Order Price",
-      minJobResponses: 1,
-      minOracleSamples: 1,
-      maxJobRangePct: 0,
+      minJobResponses: 1, // unscaled job/source quorum
+      minOracleSamples: 1, // unscaled oracle/signature quorum
+      maxJobRangePct: 0, // Intentional for this single-source verification; use a positive scaled value for normal multi-source feeds.
       jobs: [
         {
           tasks: [

--- a/solana/x402/scripts/x402Update.ts
+++ b/solana/x402/scripts/x402Update.ts
@@ -75,9 +75,9 @@ async function simulateTransaction(
 
 const ORACLE_FEED: IOracleFeed = {
   name: "X402 Paywalled RPC Call",
-  minJobResponses: 1,
-  minOracleSamples: 1,
-  maxJobRangePct: 0,
+  minJobResponses: 1, // unscaled job/source quorum
+  minOracleSamples: 1, // unscaled oracle/signature quorum
+  maxJobRangePct: 0, // Intentional for this single-use flow; use a positive scaled value for normal multi-source feeds.
   jobs: [
     {
       tasks: [


### PR DESCRIPTION
## Summary

- Fix the Solana basic managed-feed example so raw v2 `maxJobRangePct` uses `1_000_000_000` for `1%`.
- Add inline comments for intentional `maxJobRangePct: 0` / `max_job_range_pct: Some(0)` single-use and single-source examples.
- Clarify quorum fields in examples as unscaled job/source or oracle/signature counts.

## Why

Examples are frequently copied into new feeds. A raw v2 value such as `maxJobRangePct: 1` is not `1%`; it is effectively zero tolerance because the field is scaled by `1e9`.

## Validation

- Ran the user-docs boundary scanner on the touched Markdown file.
- Ran a search audit for `maxJobRangePct|max_job_range_pct|maxVariance|max_variance|max_range_percent|minJobResponses|minOracleSamples|RangeExceeded`.
- Ran `git diff --check`.
- TypeScript checks were not run because `codex-in-container` could not start Colima: `ha.sock ... connection refused` before entering the container.

## Notes

This PR intentionally excludes pre-existing unrelated dirty files and untracked local example files from the source checkout.