### PR TITLE
docs: mark PullFeed examples as legacy

### DIFF
--- a/common/variable-overrides/README.md
+++ b/common/variable-overrides/README.md
@@ -159,7 +159,7 @@ POLYGON_API_KEY=your_key bun run common/variable-overrides/testVariableOverrides
    ```
 
 3. **Use On-Chain**: When fetching oracle quotes, pass the same overrides
-   - Solana: Add to `fetchUpdateMany` options
+   - Solana/SVM: Add to `queue.fetchManagedUpdateIxs(...)` options
    - EVM: Add to contract call parameters
    - Sui: Add to transaction builder options
 
@@ -168,11 +168,15 @@ POLYGON_API_KEY=your_key bun run common/variable-overrides/testVariableOverrides
 ### Solana
 
 ```typescript
-import { Oracle } from "@switchboard-xyz/on-demand";
+import * as sb from "@switchboard-xyz/on-demand";
+import { CrossbarClient } from "@switchboard-xyz/common";
 
-const oracle = new Oracle({ ... });
-const response = await oracle.fetchUpdateMany({
-  feeds: [feedConfig],
+const { keypair, program } = await sb.AnchorUtils.loadEnv();
+const queue = await sb.Queue.loadDefault(program!);
+const crossbar = CrossbarClient.default();
+
+const instructions = await queue.fetchManagedUpdateIxs(crossbar, [feedId], {
+  payer: keypair.publicKey,
   variableOverrides: {
     API_KEY: process.env.API_KEY
   }

--- a/solana/README.md
+++ b/solana/README.md
@@ -2,7 +2,7 @@
 
 ![Switchboard Logo](https://github.com/switchboard-xyz/core-sdk/raw/main/website/static/img/icons/switchboard/avatar.png)
 
-# Switchboard On-Demand: Solana Pull Feed
+# Switchboard On-Demand: Solana Feeds
 
 **Get real-time oracle prices in your Solana program with sub-second latency and 90% lower costs.**
 
@@ -37,6 +37,10 @@ That's it! You're now fetching real-time oracle prices. 🎉
 `solana/feeds/advanced` is the current compute-optimized Pinocchio feed example.
 
 Legacy Solana examples are compatibility references. Current examples live outside `solana/legacy/**`.
+New feed-hash integrations should use `queue.fetchManagedUpdateIxs(...)` and
+canonical quote-program accounts. Classic `PullFeed.fetchUpdateIx(...)` is only
+for existing PullFeed account integrations with compatible queue/gateway
+support.
 
 ## 📋 Prerequisites
 
@@ -283,7 +287,7 @@ The oracle quote method (e.g., `feeds/advanced/scripts/runUpdate.ts`) is signifi
 #### 3. **Composable Architecture**
 The oracle quote method consists of two key components:
 
-##### a) **Secp256k1 Precompile Instruction**
+##### a) **Ed25519 Signature Verification Instruction**
 ```typescript
 const sigVerifyIx = await queue.fetchQuoteIx(crossbar, [
   argv.feedHash,
@@ -292,7 +296,7 @@ const sigVerifyIx = await queue.fetchQuoteIx(crossbar, [
   variableOverrides: {}
 });
 ```
-- Uses Solana's native secp256k1 precompile for signature verification
+- Uses Solana's native Ed25519 program for signature verification
 - Verifies oracle signatures without expensive on-chain compute
 - Batches multiple signature verifications in a single instruction
 

--- a/solana/feeds/README.md
+++ b/solana/feeds/README.md
@@ -20,10 +20,12 @@ Compute-optimized examples with performance best practices:
 **Use when**: Building production apps, need maximum performance, handling high transaction volume
 
 ### 📁 `legacy/` - Previous Generation Examples
-Examples using the older Pull Feed system (still supported):
+Examples using the older classic PullFeed account system:
 - **`runFeed.ts`** - Individual feed updates with granular control
 
-Legacy feed examples are compatibility references for older integrations.
+Legacy feed examples are compatibility and migration references only. They
+require queue/gateway support for the classic PullFeed update path and are not
+the starting point for new feed-hash integrations.
 
 ## Quick Start
 
@@ -76,15 +78,17 @@ The new system uses the **quote program** to provide:
 Examples: `basic/` and `advanced/` directories
 
 ### 🔄 Legacy Pull Feed System
-The legacy system provides:
+The legacy system is for existing classic PullFeed account integrations that
+still have queue/gateway support for that path:
 - **Granular control**: Individual feed management
 - **Direct feed accounts**: Work with specific PullFeed accounts
 - **Detailed responses**: Visibility into individual oracle responses
-- **Backwards compatibility**: Existing integrations continue to work
+- **Compatibility reference**: Useful when migrating existing PullFeed code
 
 Examples: `legacy/` directory
 
-Legacy examples remain useful for compatibility and migration reference.
+Legacy examples remain useful for compatibility and migration reference. New
+Solana/SVM custom-feed integrations should use `basic/` or `advanced/`.
 
 ## Integration Patterns
 
@@ -289,6 +293,10 @@ If migrating from legacy Pull Feeds:
 3. **Update** program to use managed oracle accounts
 4. **Test** with basic examples first
 5. **Optimize** with advanced patterns
+
+If `PullFeed.fetchUpdateIx()` or `pullFeedSubmitResponseConsensus` returns
+`ORACLE_UNAVAILABLE` while managed Ed25519 quote updates work, the integration
+is using the legacy PullFeed path against quote-program infrastructure.
 
 ## Related Documentation
 

--- a/solana/legacy/benchmarks/benchmark.ts
+++ b/solana/legacy/benchmarks/benchmark.ts
@@ -1,6 +1,11 @@
 /**
  * @fileoverview Oracle Latency Benchmark Tool
  *
+ * Legacy classic PullFeed/secp benchmark. Do not use this script for new
+ * feed-hash integrations; use solana/feeds/basic/scripts/managedUpdate.ts or
+ * solana/feeds/advanced/scripts/runUpdate.ts and canonical quote-program
+ * accounts instead.
+ *
  * This script compares the latency of Switchboard On-Demand oracles against
  * other major oracle providers (Pyth, Redstone, Supra). It measures the time
  * from when price data is published to when it's available for use.

--- a/solana/legacy/benchmarks/benchmarkCU.ts
+++ b/solana/legacy/benchmarks/benchmarkCU.ts
@@ -1,6 +1,11 @@
 /**
  * @fileoverview Compute Unit Benchmark Tool
  *
+ * Legacy classic PullFeed/secp benchmark. Do not use this script for new
+ * feed-hash integrations; use solana/feeds/basic/scripts/managedUpdate.ts or
+ * solana/feeds/advanced/scripts/runUpdate.ts and canonical quote-program
+ * accounts instead.
+ *
  * This script measures the compute units (CU) consumed by Switchboard
  * oracle updates with varying configurations. It helps developers:
  *

--- a/solana/legacy/feeds/README.md
+++ b/solana/legacy/feeds/README.md
@@ -1,10 +1,14 @@
 # Legacy Feed Scripts
 
-This directory contains deprecated feed scripts that are maintained for compatibility but are no longer recommended for new projects.
+This directory contains classic PullFeed scripts that are maintained as
+compatibility and migration references. They are no longer recommended for new
+projects.
 
 ## Deprecation Notice
 
-Support will permanently continue, but for new projects use `../../feeds/basic/scripts/managedUpdate.ts` instead, which provides:
+These scripts require queue/gateway support for the legacy PullFeed update
+path. For new projects use `../../feeds/basic/scripts/managedUpdate.ts`
+instead, which provides:
 - 90% lower costs through quote aggregation
 - Better performance with reduced network calls
 - Simplified implementation with fewer moving parts
@@ -16,7 +20,7 @@ Support will permanently continue, but for new projects use `../../feeds/basic/s
 
 **Status**: Legacy - Use `../../feeds/basic/scripts/managedUpdate.ts` instead
 
-**Purpose**: Update specific pull feed accounts with detailed oracle response visibility.
+**Purpose**: Update specific classic PullFeed accounts with detailed oracle response visibility.
 
 **Usage**:
 ```bash

--- a/solana/legacy/feeds/runFeed.ts
+++ b/solana/legacy/feeds/runFeed.ts
@@ -4,6 +4,10 @@ import yargs from "yargs";
 import { TX_CONFIG, sleep } from "./utils";
 import { DisplayState, render, initScreen, setupCleanupHandlers } from "./view";
 
+// Legacy classic PullFeed/secp path. Do not use this script for new
+// feed-hash integrations; use ../../feeds/basic/scripts/managedUpdate.ts and
+// canonical quote-program accounts instead.
+
 const argv = yargs(process.argv).options({ feed: { required: true } })
   .argv as any;
 

--- a/solana/legacy/variable-overrides/programs/sb-on-demand-solana/src/lib.rs
+++ b/solana/legacy/variable-overrides/programs/sb-on-demand-solana/src/lib.rs
@@ -1,4 +1,6 @@
 use anchor_lang::prelude::*;
+// Legacy classic PullFeed account example. New feed-hash integrations should
+// read canonical quote-program accounts instead of PullFeedAccountData.
 use switchboard_on_demand::on_demand::accounts::pull_feed::PullFeedAccountData;
 
 declare_id!("CeJiXcRwxWmFoCMy1GozyGrt4SoAXB9HmFTA1JAfmqQT");


### PR DESCRIPTION
## Summary
- clarify Solana examples so basic and advanced managed quote-program flows are the current path
- mark legacy PullFeed scripts and benchmarks as compatibility/migration references that require queue/gateway support
- update variable override docs to use queue.fetchManagedUpdateIxs for Solana/SVM

## Verification
- user-docs boundary scanner passed for touched Markdown
- search audit completed for PullFeed/quote-program/current-path wording
- git diff --check passed
- no live devnet/gateway/transaction test run